### PR TITLE
ci: run pull_request workflows on every base branch

### DIFF
--- a/.cursor/skills/merge-dependabot-prs/SKILL.md
+++ b/.cursor/skills/merge-dependabot-prs/SKILL.md
@@ -38,8 +38,9 @@ a mechanical fix was expected).
   `pr-playwright-tests.yml`) are aggregate `needs: [...]` + `if: always()`
   jobs over the slow integration/playwright matrices. If either is *absent*
   from `gh pr checks`, its matrix is still running — the PR isn't blocked.
-  (`merge-group.yml` provides instant-pass stubs of the same names inside the
-  queue itself.)
+  (`merge-group.yml` provides fast same-named jobs inside the queue itself;
+  they only check that the PR run's verdict used a base that landed, and skip
+  that check for Dependabot PRs, which cannot record it.)
 - `mergeStateStatus`/`autoMergeRequest` are unreliable for "is it actually
   queued" — query the queue directly: [references/graphql-queries.md](references/graphql-queries.md).
 

--- a/.github/actions/check-tested-base/action.yml
+++ b/.github/actions/check-tested-base/action.yml
@@ -2,7 +2,7 @@ name: "Check tested base"
 description: >-
   Merge-queue guard for a required check whose verdict comes from the
   pull_request event only. Accepts the verdict when the base it was computed
-  against is in the target branch's history or in the PR's own history.
+  against landed in the target branch, directly or through a parent PR.
 inputs:
   context:
     description: "Commit status context the pull_request run recorded (for example ci/tested-base/integration)"

--- a/.github/actions/check-tested-base/action.yml
+++ b/.github/actions/check-tested-base/action.yml
@@ -1,0 +1,22 @@
+name: "Check tested base"
+description: >-
+  Merge-queue guard for a required check whose verdict comes from the
+  pull_request event only. Accepts the verdict when the base it was computed
+  against is in the target branch's history or in the PR's own history.
+inputs:
+  context:
+    description: "Commit status context the pull_request run recorded (for example ci/tested-base/integration)"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Check tested base
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        CONTEXT: ${{ inputs.context }}
+        REPO: ${{ github.repository }}
+        MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
+        MERGE_GROUP_BASE_REF: ${{ github.event.merge_group.base_ref }}
+        MERGE_GROUP_HEAD_COMMIT_MESSAGE: ${{ github.event.merge_group.head_commit.message }}
+      run: bash "${GITHUB_ACTION_PATH}/check-tested-base.sh"

--- a/.github/actions/check-tested-base/check-tested-base.sh
+++ b/.github/actions/check-tested-base/check-tested-base.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Merge-queue guard for a required check whose real verdict comes from the
+# pull_request event only (`required`, `playwright-required`).
+#
+# The pull_request run records the base it tested against as a commit status
+# on the PR head (context = CONTEXT, description = "<base sha> <base ref>").
+# This script accepts the verdict when that base is in the target branch's
+# history or in the PR's own history. In both cases the merged tree differs
+# from the tested tree only by what the target gained since the test, which is
+# the staleness the repository already accepts (no strict up-to-date policy).
+# It rejects a base that never landed: an abandoned parent branch, or a release
+# branch after a retarget to main.
+#
+# Runs with a read-only token. Needs contents:read, pull-requests:read, and
+# statuses:read.
+set -euo pipefail
+
+: "${CONTEXT:?}" "${REPO:?}" "${MERGE_GROUP_HEAD_REF:?}" "${MERGE_GROUP_BASE_REF:?}" "${GH_TOKEN:?}"
+
+# refs/heads/gh-readonly-queue/<target>/pr-<N>-<base sha>. The target can
+# contain slashes (release/vX.Y), so anchor on the trailing "pr-<N>-<sha>".
+if [[ "${MERGE_GROUP_HEAD_REF}" =~ /pr-([0-9]+)-[0-9a-f]{40}$ ]]; then
+  PR_NUMBER="${BASH_REMATCH[1]}"
+elif [[ "${MERGE_GROUP_HEAD_COMMIT_MESSAGE:-}" =~ \(#([0-9]+)\) ]]; then
+  PR_NUMBER="${BASH_REMATCH[1]}"
+else
+  echo "::error::Cannot find a PR number in merge group ref '${MERGE_GROUP_HEAD_REF}'."
+  exit 1
+fi
+TARGET="${MERGE_GROUP_BASE_REF#refs/heads/}"
+
+pr_json="$(gh pr view "${PR_NUMBER}" --repo "${REPO}" --json headRefOid,isCrossRepository,author)"
+HEAD_SHA="$(jq -r '.headRefOid' <<<"${pr_json}")"
+IS_CROSS_REPO="$(jq -r '.isCrossRepository' <<<"${pr_json}")"
+AUTHOR="$(jq -r '.author.login' <<<"${pr_json}")"
+echo "PR #${PR_NUMBER} by ${AUTHOR}: head ${HEAD_SHA} -> ${TARGET}"
+
+# Fork and Dependabot runs get a read-only token, so they cannot record.
+if [[ "${IS_CROSS_REPO}" == "true" || "${AUTHOR}" == "app/dependabot" ]]; then
+  echo "::warning::PR #${PR_NUMBER} runs with a read-only token and cannot record ${CONTEXT}. Skipping this check."
+  exit 0
+fi
+
+record="$(gh api "repos/${REPO}/commits/${HEAD_SHA}/status" \
+  | jq -r --arg ctx "${CONTEXT}" '.statuses[] | select(.context == $ctx) | .description')"
+if [[ -z "${record}" ]]; then
+  echo "::error::No ${CONTEXT} record on ${HEAD_SHA} (PR #${PR_NUMBER}). The pull_request run that produced this verdict predates the record step, or did not finish. Push a commit, or close and reopen the PR, to run it again. Then re-queue. 'Re-run jobs' does not help: it reuses the old base."
+  exit 1
+fi
+TESTED_BASE="${record%% *}"
+TESTED_REF="${record#* }"
+
+# True when $1 is in the history of $2. The compare API reports base...head as
+# "ahead" or "identical" only when base is an ancestor of head.
+is_ancestor() {
+  local status
+  if ! status="$(gh api "repos/${REPO}/compare/${1}...${2}" --jq '.status' 2>/dev/null)"; then
+    status="unknown"
+  fi
+  echo "compare ${1}...${2}: ${status}"
+  [[ "${status}" == "ahead" || "${status}" == "identical" ]]
+}
+
+if is_ancestor "${TESTED_BASE}" "${TARGET}" || is_ancestor "${TESTED_BASE}" "${HEAD_SHA}"; then
+  echo "${CONTEXT} for PR #${PR_NUMBER} ran against ${TESTED_BASE} (${TESTED_REF}). Accepted."
+  exit 0
+fi
+
+echo "::error::${CONTEXT} for PR #${PR_NUMBER} ran against ${TESTED_BASE} (${TESTED_REF}), which is in neither ${TARGET} nor the PR's own history. That base never landed, so the verdict does not cover this merge. Rebase onto ${TARGET}, push, and re-queue."
+exit 1

--- a/.github/actions/check-tested-base/check-tested-base.sh
+++ b/.github/actions/check-tested-base/check-tested-base.sh
@@ -4,12 +4,13 @@
 #
 # The pull_request run records the base it tested against as a commit status
 # on the PR head (context = CONTEXT, description = "<base sha> <base ref>").
-# This script accepts the verdict when that base is in the target branch's
-# history or in the PR's own history. In both cases the merged tree differs
-# from the tested tree only by what the target gained since the test, which is
-# the staleness the repository already accepts (no strict up-to-date policy).
-# It rejects a base that never landed: an abandoned parent branch, or a release
-# branch after a retarget to main.
+# This script accepts the verdict when that base has landed in the target
+# branch, or when it is the tip of a parent PR that squash-merged into the
+# target or is still open against it (a stack in flight). In each case the
+# merged tree differs from the tested tree only by what the target gained
+# since the test, which is the staleness the repository already accepts (no
+# strict up-to-date policy). It rejects a base that never landed: an abandoned
+# parent branch, or a release branch after a retarget to main.
 #
 # Runs with a read-only token. Needs contents:read, pull-requests:read, and
 # statuses:read.
@@ -36,6 +37,7 @@ AUTHOR="$(jq -r '.author.login' <<<"${pr_json}")"
 echo "PR #${PR_NUMBER} by ${AUTHOR}: head ${HEAD_SHA} -> ${TARGET}"
 
 # Fork and Dependabot runs get a read-only token, so they cannot record.
+# `gh pr view` reports GitHub App authors with an "app/" prefix.
 if [[ "${IS_CROSS_REPO}" == "true" || "${AUTHOR}" == "app/dependabot" ]]; then
   echo "::warning::PR #${PR_NUMBER} runs with a read-only token and cannot record ${CONTEXT}. Skipping this check."
   exit 0
@@ -61,10 +63,52 @@ is_ancestor() {
   [[ "${status}" == "ahead" || "${status}" == "identical" ]]
 }
 
-if is_ancestor "${TESTED_BASE}" "${TARGET}" || is_ancestor "${TESTED_BASE}" "${HEAD_SHA}"; then
-  echo "${CONTEXT} for PR #${PR_NUMBER} ran against ${TESTED_BASE} (${TESTED_REF}). Accepted."
+# True when a chain of open same-repo PRs leads from head branch $1 to TARGET.
+reaches_target() {
+  local ref="$1" depth="${2:-0}" base
+  [[ "${ref}" == "${TARGET}" ]] && return 0
+  ((depth >= 10)) && return 1
+  while IFS= read -r base; do
+    [[ -z "${base}" ]] && continue
+    echo "open PR chain: ${ref} -> ${base}"
+    if reaches_target "${base}" $((depth + 1)); then
+      return 0
+    fi
+  done < <(gh pr list --repo "${REPO}" --head "${ref}" --state open --limit 20 \
+    --json baseRefName,isCrossRepository \
+    --jq '.[] | select(.isCrossRepository == false) | .baseRefName')
+  return 1
+}
+
+if is_ancestor "${TESTED_BASE}" "${TARGET}"; then
+  echo "${CONTEXT} for PR #${PR_NUMBER} ran against ${TESTED_BASE} (${TESTED_REF}), which is in ${TARGET}. Accepted."
   exit 0
 fi
 
-echo "::error::${CONTEXT} for PR #${PR_NUMBER} ran against ${TESTED_BASE} (${TESTED_REF}), which is in neither ${TARGET} nor the PR's own history. That base never landed, so the verdict does not cover this merge. Rebase onto ${TARGET}, push, and re-queue."
+# A stacked PR tests against its parent's tip. Under squash merge that tip
+# never enters the target as-is, so look at the parent PR instead: the tested
+# tip must be part of the parent's head, and the parent must have merged into
+# the target or still be open against it.
+parents="$(gh pr list --repo "${REPO}" --head "${TESTED_REF}" --state all --limit 20 \
+  --json number,state,baseRefName,headRefOid,mergeCommit,isCrossRepository \
+  --jq '[.[] | select(.isCrossRepository == false and (.state == "MERGED" or .state == "OPEN"))]
+        | sort_by(.state)[]
+        | [.number, .state, .baseRefName, .headRefOid, (.mergeCommit.oid // "")] | @tsv')"
+while IFS=$'\t' read -r number state base head merge; do
+  [[ -z "${number}" ]] && continue
+  echo "parent PR #${number} (${state}): ${TESTED_REF} -> ${base}"
+  if ! is_ancestor "${TESTED_BASE}" "${head}"; then
+    continue
+  fi
+  if [[ "${state}" == "MERGED" && -n "${merge}" ]] && is_ancestor "${merge}" "${TARGET}"; then
+    echo "${CONTEXT} for PR #${PR_NUMBER} ran against ${TESTED_BASE} (${TESTED_REF}); parent PR #${number} merged into ${TARGET}. Accepted."
+    exit 0
+  fi
+  if [[ "${state}" == "OPEN" ]] && reaches_target "${base}"; then
+    echo "${CONTEXT} for PR #${PR_NUMBER} ran against ${TESTED_BASE} (${TESTED_REF}); parent PR #${number} is open against ${TARGET}. Accepted."
+    exit 0
+  fi
+done <<<"${parents}"
+
+echo "::error::${CONTEXT} for PR #${PR_NUMBER} ran against ${TESTED_BASE} (${TESTED_REF}). That tip is not in ${TARGET}, and no PR from ${TESTED_REF} that contains it merged into or is open against ${TARGET}. The verdict does not cover this merge. Rebase onto ${TARGET}, push, and re-queue."
 exit 1

--- a/.github/workflows/merge-group.yml
+++ b/.github/workflows/merge-group.yml
@@ -5,27 +5,41 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
+  statuses: read
 
 jobs:
-  # This job immediately succeeds to satisfy branch protection rules on merge_group events.
-  # There is a similarly named "required" job in pr-integration-tests.yml which runs the actual
-  # integration tests. That job runs on both pull_request and merge_group events, and this job
-  # exists solely to provide a fast-passing check with the same name for branch protection.
-  # The actual tests remain enforced on presubmit (pull_request events).
+  # `required` and `playwright-required` are required checks on main. Their
+  # real verdicts come from the pull_request runs of pr-integration-tests.yml
+  # and pr-playwright-tests.yml. The same-named jobs there also run on
+  # merge_group, but the queue does not wait for them: these two jobs satisfy
+  # the ruleset in seconds. Before passing, each one checks that the
+  # pull_request verdict was computed against a base that landed, so a PR that
+  # was retargeted or stacked on an abandoned branch cannot merge on a stale
+  # verdict (see .github/actions/check-tested-base).
   required:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 5
     steps:
-      - name: Success
-        run: echo "Success"
-  # This job immediately succeeds to satisfy branch protection rules on merge_group events.
-  # There is a similarly named "playwright-required" job in pr-playwright-tests.yml which runs
-  # the actual playwright tests. That job runs on both pull_request and merge_group events, and
-  # this job exists solely to provide a fast-passing check with the same name for branch protection.
-  # The actual tests remain enforced on presubmit (pull_request events).
+      - name: Checkout check-tested-base action
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/actions/check-tested-base
+      - name: Check the integration verdict was computed against a landed base
+        uses: ./.github/actions/check-tested-base
+        with:
+          context: ci/tested-base/integration
   playwright-required:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 5
     steps:
-      - name: Success
-        run: echo "Success"
+      - name: Checkout check-tested-base action
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/actions/check-tested-base
+      - name: Check the playwright verdict was computed against a landed base
+        uses: ./.github/actions/check-tested-base
+        with:
+          context: ci/tested-base/playwright

--- a/.github/workflows/pr-connector-filter-eval.yml
+++ b/.github/workflows/pr-connector-filter-eval.yml
@@ -9,7 +9,6 @@ concurrency:
 # triggered ONLY when the prompt (or the flow/suite around it) changes.
 on:
   pull_request:
-    branches: [main]
     paths:
       - "backend/onyx/prompts/filter_extration.py"
       - "backend/onyx/secondary_llm_flows/source_filter.py"

--- a/.github/workflows/pr-craft-compose-integration.yml
+++ b/.github/workflows/pr-craft-compose-integration.yml
@@ -24,7 +24,6 @@ on:
     - cron: "0 7 * * *"   # 07:00 UTC nightly
   merge_group:
   pull_request:
-    branches: [main]
     # NOTE: Intentionally no `paths:` filter. We always trigger and let the
     # `changes` job below decide whether the real test job runs.
   push:

--- a/.github/workflows/pr-craft-compose-tests.yml
+++ b/.github/workflows/pr-craft-compose-tests.yml
@@ -9,7 +9,6 @@ concurrency:
 on:
   merge_group:
   pull_request:
-    branches: [main]
     paths:
       - "backend/onyx/sandbox_proxy/**"
       - "backend/onyx/server/features/build/configs.py"

--- a/.github/workflows/pr-craft-k8s-tests.yml
+++ b/.github/workflows/pr-craft-k8s-tests.yml
@@ -21,7 +21,6 @@ on:
     - cron: "0 7 * * *"   # 07:00 UTC nightly
   merge_group:
   pull_request:
-    branches: [main]
     # NOTE: Intentionally no `paths:` filter. Trigger-level `paths:` is ignored
     # for `merge_group`, so we always trigger and let the `changes` job below
     # decide whether the real test job runs (matches the docker-compose lane

--- a/.github/workflows/pr-database-tests.yml
+++ b/.github/workflows/pr-database-tests.yml
@@ -6,9 +6,6 @@ concurrency:
 on:
   merge_group:
   pull_request:
-    branches:
-      - main
-      - "release/**"
   push:
     tags:
       - "v*.*.*"

--- a/.github/workflows/pr-desktop-build.yml
+++ b/.github/workflows/pr-desktop-build.yml
@@ -6,9 +6,6 @@ concurrency:
 on:
   merge_group:
   pull_request:
-    branches:
-      - main
-      - "release/**"
     paths:
       - "desktop/**"
       - ".github/workflows/pr-desktop-build.yml"

--- a/.github/workflows/pr-external-dependency-unit-tests.yml
+++ b/.github/workflows/pr-external-dependency-unit-tests.yml
@@ -6,7 +6,6 @@ concurrency:
 on:
   merge_group:
   pull_request:
-    branches: [main]
     paths:
       - "backend/**"
       - "pyproject.toml"

--- a/.github/workflows/pr-golang-tests.yml
+++ b/.github/workflows/pr-golang-tests.yml
@@ -6,9 +6,6 @@ concurrency:
 on:
   merge_group:
   pull_request:
-    branches:
-      - main
-      - "release/**"
   push:
     tags:
       - "v*.*.*"

--- a/.github/workflows/pr-helm-chart-testing.yml
+++ b/.github/workflows/pr-helm-chart-testing.yml
@@ -6,7 +6,6 @@ concurrency:
 on:
   merge_group:
   pull_request:
-    branches: [main]
   push:
     tags:
       - "v*.*.*"
@@ -45,13 +44,16 @@ jobs:
           uv_version: "0.11.25"
 
       # even though we specify chart-dirs in ct.yaml, it isn't used by ct for the list-changed command...
+      # Diff against the PR's own base so a stacked PR only lists its own chart
+      # changes. `github.base_ref` is empty outside pull_request, so merge_group,
+      # tag pushes, and manual runs fall back to the default branch.
       - name: Run chart-testing (list-changed)
         id: list-changed
         env:
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          TARGET_BRANCH: ${{ github.base_ref || github.event.repository.default_branch }}
         run: |
-          echo "default_branch: ${DEFAULT_BRANCH}"
-          changed=$(ct list-changed --remote origin --target-branch ${DEFAULT_BRANCH} --chart-dirs deployment/helm/charts)
+          echo "target_branch: ${TARGET_BRANCH}"
+          changed=$(ct list-changed --remote origin --target-branch "${TARGET_BRANCH}" --chart-dirs deployment/helm/charts)
           echo "list-changed output: $changed"
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-helm-chart-version.yml
+++ b/.github/workflows/pr-helm-chart-version.yml
@@ -14,9 +14,13 @@ concurrency:
 # counts too). Because of this it cannot be a *required* branch-protection check
 # -- a required check that is filtered out on unrelated PRs stays stuck "pending"
 # and blocks merges. It is enforced as a visible failing check on chart PRs.
+#
+# Runs on PRs into any branch except release/** (a stacked PR still needs a
+# version above main, because that is where the chart publishes from). Release
+# branches never publish the chart, so the check does not apply there.
 on:
   pull_request:
-    branches: [main]
+    branches-ignore: ["release/**"]
     paths:
       - "deployment/helm/charts/onyx/**"
       - "deployment/helm/charts/onyx-cnpg-crds/**"

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -6,9 +6,6 @@ concurrency:
 on:
   merge_group:
   pull_request:
-    branches:
-      - main
-      - "release/**"
     # NOTE: Intentionally no `paths:` filter. We always trigger and let the
     # `changes` job below decide whether the real test matrix runs. This
     # avoids the dual-workflow skip pattern where a `paths-ignore`'d skip
@@ -695,6 +692,9 @@ jobs:
     timeout-minutes: 5
     needs: [changes, integration-tests, onyx-lite-tests, multitenant-tests]
     if: ${{ always() }}
+    # Writes the tested-base commit status in the last step.
+    permissions:
+      statuses: write
     steps:
       - name: Check job status
         env:
@@ -723,3 +723,26 @@ jobs:
             exit 1
           fi
           echo "All tests passed."
+      # Record which base tip this verdict used. merge-group.yml refuses to
+      # merge a PR whose verdict used a base that is in neither the target
+      # branch nor the PR's own history (see .github/actions/check-tested-base).
+      # Fork and Dependabot runs have a read-only token and cannot record.
+      - name: Record tested base
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'dependabot[bot]'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          DESCRIPTION="${BASE_SHA} ${BASE_REF}"
+          gh api --method POST "repos/${REPO}/statuses/${HEAD_SHA}" \
+            -f state=success \
+            -f context=ci/tested-base/integration \
+            -f description="${DESCRIPTION:0:140}" \
+            -f target_url="${RUN_URL}"

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -724,8 +724,8 @@ jobs:
           fi
           echo "All tests passed."
       # Record which base tip this verdict used. merge-group.yml refuses to
-      # merge a PR whose verdict used a base that is in neither the target
-      # branch nor the PR's own history (see .github/actions/check-tested-base).
+      # merge a PR whose verdict used a base that never landed in the target
+      # (see .github/actions/check-tested-base).
       # Fork and Dependabot runs have a read-only token and cannot record.
       - name: Record tested base
         if: >-

--- a/.github/workflows/pr-jest-tests.yml
+++ b/.github/workflows/pr-jest-tests.yml
@@ -6,9 +6,6 @@ concurrency:
 on:
   merge_group:
   pull_request:
-    branches:
-      - main
-      - "release/**"
   push:
     tags:
       - "v*.*.*"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -2,8 +2,6 @@ name: PR Labeler
 
 on:
   pull_request:
-    branches:
-      - main
     types:
       - opened
       - reopened

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -1281,8 +1281,8 @@ jobs:
           fi
           echo "All tests passed."
       # Record which base tip this verdict used. merge-group.yml refuses to
-      # merge a PR whose verdict used a base that is in neither the target
-      # branch nor the PR's own history (see .github/actions/check-tested-base).
+      # merge a PR whose verdict used a base that never landed in the target
+      # (see .github/actions/check-tested-base).
       # Fork and Dependabot runs have a read-only token and cannot record.
       - name: Record tested base
         if: >-

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -6,9 +6,6 @@ concurrency:
 on:
   merge_group:
   pull_request:
-    branches:
-      - main
-      - "release/**"
     # NOTE: Intentionally no `paths:` filter. We always trigger and let the
     # `changes` job below decide whether the real test matrix runs. This
     # avoids the dual-workflow skip pattern where a `paths-ignore`'d skip
@@ -1019,8 +1016,18 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           if [ "${EVENT_NAME}" = "pull_request" ]; then
-            # PRs compare against the base branch (e.g. main, release/2.5)
-            echo "rev=${BASE_REF}" >> "$GITHUB_OUTPUT"
+            # PRs compare against the base branch (e.g. main, release/2.5).
+            # Baselines are only written from main/release/*, so a PR into any
+            # other branch (a stacked PR) falls back to main.
+            case "${BASE_REF}" in
+              main|release/*)
+                echo "rev=${BASE_REF}" >> "$GITHUB_OUTPUT"
+                ;;
+              *)
+                echo "No baseline for base branch '${BASE_REF}'; comparing against main"
+                echo "rev=main" >> "$GITHUB_OUTPUT"
+                ;;
+            esac
           elif [ "${EVENT_NAME}" = "merge_group" ]; then
             # Merge queue compares against the target branch (e.g. refs/heads/main -> main)
             echo "rev=${MERGE_GROUP_BASE_REF#refs/heads/}" >> "$GITHUB_OUTPUT"
@@ -1228,6 +1235,9 @@ jobs:
         playwright-tests-oauth-okta,
       ]
     if: ${{ always() }}
+    # Writes the tested-base commit status in the last step.
+    permissions:
+      statuses: write
     steps:
       - name: Check job status
         env:
@@ -1270,3 +1280,26 @@ jobs:
             exit 1
           fi
           echo "All tests passed."
+      # Record which base tip this verdict used. merge-group.yml refuses to
+      # merge a PR whose verdict used a base that is in neither the target
+      # branch nor the PR's own history (see .github/actions/check-tested-base).
+      # Fork and Dependabot runs have a read-only token and cannot record.
+      - name: Record tested base
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'dependabot[bot]'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          DESCRIPTION="${BASE_SHA} ${BASE_REF}"
+          gh api --method POST "repos/${REPO}/statuses/${HEAD_SHA}" \
+            -f state=success \
+            -f context=ci/tested-base/playwright \
+            -f description="${DESCRIPTION:0:140}" \
+            -f target_url="${RUN_URL}"

--- a/.github/workflows/pr-python-checks.yml
+++ b/.github/workflows/pr-python-checks.yml
@@ -6,9 +6,6 @@ concurrency:
 on:
   merge_group:
   pull_request:
-    branches:
-      - main
-      - "release/**"
   push:
     tags:
       - "v*.*.*"

--- a/.github/workflows/pr-python-connector-tests.yml
+++ b/.github/workflows/pr-python-connector-tests.yml
@@ -30,7 +30,6 @@ on:
   # is not evaluated for tag pushes, so the `v*.*.*` release trigger below still
   # fires regardless of changed files.
   pull_request:
-    branches: [main]
     paths:
       - "backend/**"
       - "pyproject.toml"

--- a/.github/workflows/pr-python-tests.yml
+++ b/.github/workflows/pr-python-tests.yml
@@ -6,9 +6,6 @@ concurrency:
 on:
   merge_group:
   pull_request:
-    branches:
-      - main
-      - 'release/**'
   push:
     tags:
       - "v*.*.*"

--- a/.github/workflows/pr-recommended-models-chat-test.yml
+++ b/.github/workflows/pr-recommended-models-chat-test.yml
@@ -13,7 +13,6 @@ concurrency:
 
 on:
   pull_request:
-    branches: [main]
     paths:
       - "backend/onyx/llm/well_known_providers/recommended-models.json"
       - ".github/workflows/pr-recommended-models-chat-test.yml"

--- a/.github/workflows/pr-storybook-build.yml
+++ b/.github/workflows/pr-storybook-build.yml
@@ -9,9 +9,6 @@ concurrency:
 on:
   merge_group:
   pull_request:
-    branches:
-      - main
-      - "release/**"
     paths:
       - "web/**"
       - ".github/workflows/pr-storybook-build.yml"

--- a/.github/workflows/pr-terraform-provider-tests.yml
+++ b/.github/workflows/pr-terraform-provider-tests.yml
@@ -32,7 +32,6 @@ on:
     - cron: "0 8 * * *" # 08:00 UTC nightly
   merge_group:
   pull_request:
-    branches: [main]
     # NOTE: Intentionally no `paths:` filter. We always trigger and let the
     # `changes` job below decide whether the real test job runs. This avoids
     # the dual-workflow skip pattern where a `paths-ignore`'d skip workflow can


### PR DESCRIPTION
## Description

Most `pr-*.yml` workflows only ran on PRs into `main` (or `release/**`). A PR into any other branch got no test CI. Native GitHub stacks (`gh stack`) already matched the filter for every PR in the stack, but manually stacked PRs, PRs linked into a stack after their last push, and ad-hoc PRs into feature branches got only quality-checks, linear, and audit.

This PR:

- Drops the `branches:` filter from the `pull_request` trigger in 19 `pr-*.yml` workflows. `merge_group`, `paths:`, `types:`, and tag or release push triggers are unchanged.
- Fixes the three places that read the base branch:
  - `pr-helm-chart-version.yml` keeps comparing against `main` (where the chart publishes from) and skips `release/**` PRs via `branches-ignore`.
  - `pr-helm-chart-testing.yml` runs `ct list-changed` against the PR base, so a stacked PR only lists its own chart changes.
  - `pr-playwright-tests.yml` falls back to the `main` visual-regression baseline when the base has none. Today a stacked PR compares against nothing and reports every screenshot as "Added".
- Adds a merge-queue guard for the two checks that are enforced on `pull_request` only (`required`, `playwright-required`). The `pull_request` run records the base it tested against as a commit status (`ci/tested-base/integration`, `ci/tested-base/playwright`). The same-named jobs in `merge-group.yml` accept the queue entry only when that base landed in the target branch: directly, or as the tip of a parent PR that merged into the target or is still open against it (a stack in flight). Either way the merged tree differs from the tested tree only by what the target gained since the test, which the queue already accepts. It rejects a base that never landed, such as a release branch after a retarget to `main`, or an abandoned parent branch. Logic lives in `.github/actions/check-tested-base`.

### Concessions

- **Rollout**: every open non-fork, non-Dependabot PR has no record yet. Its first merge attempt is dequeued with a message to push a commit or close and reopen. "Re-run jobs" does not help because it reuses the old base.
- **Retargets stay silent**: retargeting a PR fires only `edited`, which we deliberately do not run on (it would cancel in-flight runs through the `cancel-in-progress` concurrency groups and can overwrite a real failure with a skipped-green check). The queue guard covers the retarget case at the point that matters.
- **Fork and Dependabot PRs are exempt** from the guard. Their runs get a read-only token and cannot record. Same posture as today.
- **Checks on PRs into feature branches are advisory**: no ruleset targets feature branches. Prefer `gh stack`, which enforces `main`'s ruleset on every PR in the stack and rebases children after a merge.
- **Cost**: each PR in a stack runs its own CI on every push to its head branch. A restack of N branches is N runs. The `changes` jobs still gate the expensive lanes.
- **Release-branch PRs** now also run the lanes that were `main`-only (craft, terraform, connector tests, helm chart testing). None is required by the release ruleset.
- **Connector tests** (real external APIs) now run on stacked PRs that touch `backend/**`.
- **Helm chart version on a stacked child** compares against `main` only, so a child that inherits the parent's bump passes until the parent publishes it.
- **Visual regression on a stacked child** shows parent + child changes until the parent lands.

## How Has This Been Tested?

- `pre-commit` on every touched file: check-yaml, actionlint, zizmor, shellcheck.
- The queue script was dry-run locally against the live repo: PR-number parse from the queue ref and from the squash-message fallback, slash-containing release targets, the Dependabot exemption, and the missing-record error.
- With a `gh` shim supplying canned records, the guard ran against live PRs: accept via the target, accept via an open parent PR (one hop, and a four-PR chain), accept via a squash-merged parent PR, reject a release tip after a retarget to `main`, reject an abandoned parent branch, reject a tip that the open parent no longer contains, and reject an unknown SHA.
- This PR itself exercises the record step: both `ci/tested-base/*` statuses landed on the first commit with base `main`. Next: a throwaway child PR based on this branch to confirm the lanes run on a stacked PR and the baseline fallback, then enqueue it after retargeting to `main` to see the guard in a real `merge_group` run.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Most `pr-*.yml` workflows only ran on PRs into `main` (or `release/**`), so stacked PRs and PRs into feature branches got no test CI. This drops the `branches:` filter from the `pull_request` trigger in 19 workflows so every PR runs the same test lanes.

- The `required` and `playwright-required` merge-queue jobs now pass only when the PR-run verdict was computed against a base that landed in the target or is the tip of a parent PR merged into or open against it; Fork and Dependabot PRs are exempt because they cannot record it.
- Helm chart version still compares against `main` and skips `release/**`; helm chart testing diffs against the PR base; the Playwright visual-regression baseline falls back to `main` when the base has no baseline.

**Rollout**
- Existing open PRs have no tested-base record, so their first queue attempt fails; push a commit or close and reopen. Re-running jobs reuses the old base and won't help.
- Retargeting a PR doesn't re-run tests — the queue guard rejects the stale verdict at merge time.
- Release-branch PRs now run the previously `main`-only lanes (craft, terraform, connector, helm chart testing), and connector tests run on stacked PRs touching `backend/**`.
- Visual regression on a stacked child shows parent + child changes until the parent lands, and a stacked child's helm chart version passes until the parent publishes it.

<sup>Written for commit 1b4a0d0a82ed577508759c322415551fd91e99d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

