### PR TITLE
feat(connectors): add Jira Service Management connector (#2281)

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -259,6 +259,7 @@ class DocumentSource(str, Enum):
     OUTLINE = "outline"
     CONFLUENCE = "confluence"
     JIRA = "jira"
+    JIRA_SERVICE_MANAGEMENT = "jira_service_management"
     SLAB = "slab"
     PRODUCTBOARD = "productboard"
     FILE = "file"
@@ -781,6 +782,7 @@ DocumentSourceDescription: dict[DocumentSource, str] = {
     DocumentSource.OUTLINE: "Documentation and knowledge base pages",
     DocumentSource.CONFLUENCE: "Wiki pages, spaces, and documentation",
     DocumentSource.JIRA: "Issues, tickets, and project tracking",
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: "Customer service requests, incidents, and service desk tickets",
     DocumentSource.SLAB: "Documentation and knowledge base pages",
     DocumentSource.PRODUCTBOARD: "Product management boards and insights",
     DocumentSource.FILE: "Uploaded files",

--- a/backend/onyx/connectors/jira/connector.py
+++ b/backend/onyx/connectors/jira/connector.py
@@ -395,6 +395,7 @@ def process_jira_issue(
     comment_email_blacklist: tuple[str, ...] = (),
     labels_to_skip: set[str] | None = None,
     parent_hierarchy_raw_node_id: str | None = None,
+    source: DocumentSource = DocumentSource.JIRA,
 ) -> Document | None:
     if labels_to_skip:
         if any(label in issue.fields.labels for label in labels_to_skip):
@@ -487,7 +488,7 @@ def process_jira_issue(
     return Document(
         id=page_url,
         sections=[TextSection(link=page_url, text=ticket_content)],
-        source=DocumentSource.JIRA,
+        source=source,
         semantic_identifier=f"{issue.key}: {issue.fields.summary}",
         title=f"{issue.key} {issue.fields.summary}",
         doc_updated_at=time_str_to_utc(issue.fields.updated),
@@ -542,6 +543,7 @@ class JiraConnector(
         self.labels_to_skip = set(labels_to_skip)
         self.jql_query = jql_query
         self.scoped_token = scoped_token
+        self.source = DocumentSource.JIRA
         self._jira_client: JIRA | None = None
         # Cache project permissions to avoid fetching them repeatedly across runs
         self._project_permissions_cache: dict[str, Any] = {}
@@ -703,6 +705,20 @@ class JiraConnector(
         # the document belongs directly under the project in the hierarchy
         return project_key
 
+    def _process_issue(
+        self,
+        issue: Issue,
+        parent_hierarchy_raw_node_id: str | None = None,
+    ) -> Document | None:
+        return process_jira_issue(
+            jira_base_url=self.jira_base,
+            issue=issue,
+            comment_email_blacklist=self.comment_email_blacklist,
+            labels_to_skip=self.labels_to_skip,
+            parent_hierarchy_raw_node_id=parent_hierarchy_raw_node_id,
+            source=self.source,
+        )
+
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
         self._jira_client = build_jira_client(
             credentials=credentials,
@@ -827,11 +843,8 @@ class JiraConnector(
                     else None
                 )
 
-                if document := process_jira_issue(
-                    jira_base_url=self.jira_base,
+                if document := self._process_issue(
                     issue=issue,
-                    comment_email_blacklist=self.comment_email_blacklist,
-                    labels_to_skip=self.labels_to_skip,
                     parent_hierarchy_raw_node_id=parent_hierarchy_raw_node_id,
                 ):
                     # Add permission information to the document if requested

--- a/backend/onyx/connectors/jira_service_management/__init__.py
+++ b/backend/onyx/connectors/jira_service_management/__init__.py
@@ -1,0 +1,1 @@
+# Jira Service Management Connector

--- a/backend/onyx/connectors/jira_service_management/connector.py
+++ b/backend/onyx/connectors/jira_service_management/connector.py
@@ -1,0 +1,304 @@
+from typing import Any
+
+from jira.resources import Issue
+
+from onyx.configs.app_configs import (
+    INDEX_BATCH_SIZE,
+    JIRA_CONNECTOR_LABELS_TO_SKIP,
+    JIRA_CONNECTOR_MAX_TICKET_SIZE,
+)
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.cross_connector_utils.miscellaneous_utils import (
+    time_str_to_utc,
+)
+from onyx.connectors.exceptions import (
+    ConnectorValidationError,
+)
+from onyx.connectors.interfaces import SecondsSinceUnixEpoch
+from onyx.connectors.models import (
+    ConnectorMissingCredentialError,
+    Document,
+    TextSection,
+)
+from onyx.connectors.jira.connector import (
+    _FIELD_ASSIGNEE,
+    _FIELD_ASSIGNEE_EMAIL,
+    _FIELD_CREATED,
+    _FIELD_DUEDATE,
+    _FIELD_ISSUETYPE,
+    _FIELD_KEY,
+    _FIELD_LABELS,
+    _FIELD_PARENT,
+    _FIELD_PRIORITY,
+    _FIELD_PROJECT,
+    _FIELD_PROJECT_NAME,
+    _FIELD_REPORTER,
+    _FIELD_REPORTER_EMAIL,
+    _FIELD_RESOLUTION,
+    _FIELD_RESOLUTION_DATE,
+    _FIELD_RESOLUTION_DATE_KEY,
+    _FIELD_STATUS,
+    _FIELD_UPDATED,
+    JiraConnector,
+)
+from onyx.connectors.jira.utils import (
+    best_effort_basic_expert_info,
+    best_effort_get_field_from_issue,
+    build_jira_url,
+    extract_text_from_adf,
+)
+from onyx.connectors.jira_service_management.utils import (
+    FIELD_CUSTOMER_REQUEST_TYPE,
+    FIELD_ORGANIZATIONS,
+    FIELD_SLA_STATUS,
+    extract_customer_request_type,
+    extract_organizations,
+    extract_sla_info,
+    get_jsm_comment_strs,
+)
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+class JiraServiceManagementConnector(JiraConnector):
+    def __init__(
+        self,
+        jira_base_url: str,
+        project_key: str,
+        comment_email_blacklist: list[str] | None = None,
+        batch_size: int = INDEX_BATCH_SIZE,
+        labels_to_skip: list[str] = JIRA_CONNECTOR_LABELS_TO_SKIP,
+        jql_query: str | None = None,
+        scoped_token: bool = False,
+        include_attachments: bool = False,
+        include_internal_comments: bool = False,
+    ) -> None:
+        if jql_query and project_key:
+            if "project" not in jql_query.lower():
+                jql_query = f"project = '{project_key}' AND ({jql_query})"
+
+        super().__init__(
+            jira_base_url=jira_base_url,
+            project_key=project_key,
+            comment_email_blacklist=comment_email_blacklist,
+            batch_size=batch_size,
+            labels_to_skip=labels_to_skip,
+            jql_query=jql_query,
+            scoped_token=scoped_token,
+        )
+        self.source = DocumentSource.JIRA_SERVICE_MANAGEMENT
+        self.include_attachments = include_attachments
+        self.include_internal_comments = include_internal_comments
+
+    def _get_jql_query(
+        self, start: SecondsSinceUnixEpoch, end: SecondsSinceUnixEpoch
+    ) -> str:
+        base_jql = super()._get_jql_query(start, end)
+        if self.labels_to_skip:
+            skipped = ", ".join(f'"{lbl}"' for lbl in self.labels_to_skip)
+            return f"({base_jql}) AND (labels is EMPTY OR labels not in ({skipped}))"
+        return base_jql
+
+    def validate_connector_settings(self) -> None:
+        if self._jira_client is None:
+            raise ConnectorMissingCredentialError("Jira Service Management")
+
+        if not self.jira_project or not self.jira_project.strip():
+            raise ConnectorValidationError(
+                "A Jira Service Management project key is required."
+            )
+
+        # Validate project exists
+        try:
+            proj = self.jira_client.project(self.jira_project)
+            proj_type = getattr(proj, "projectTypeKey", None)
+            if proj_type and proj_type != "service_desk":
+                raise ConnectorValidationError(
+                    f"Project '{self.jira_project}' has type '{proj_type}', expected 'service_desk' for Jira Service Management."
+                )
+        except Exception as e:
+            self._handle_jira_connector_settings_error(e)
+
+        # If custom JQL query is provided, validate it
+        if self.jql_query:
+            try:
+                from onyx.connectors.jira.connector import _perform_jql_search
+
+                next(
+                    iter(
+                        _perform_jql_search(
+                            jira_client=self.jira_client,
+                            jql=self.jql_query,
+                            start=0,
+                            max_results=1,
+                            all_issue_ids=[],
+                        )
+                    ),
+                    None,
+                )
+            except Exception as e:
+                self._handle_jira_connector_settings_error(e)
+
+    def _process_issue(
+        self,
+        issue: Issue,
+        parent_hierarchy_raw_node_id: str | None = None,
+    ) -> Document | None:
+        if self.labels_to_skip:
+            issue_labels = getattr(issue.fields, "labels", [])
+            if any(label in issue_labels for label in self.labels_to_skip):
+                logger.info(
+                    "Skipping %s because it has a label to skip. Found labels: %s.",
+                    issue.key,
+                    issue_labels,
+                )
+                return None
+
+        # Extract description
+        raw_fields = getattr(issue, "raw", {}).get("fields", {})
+        raw_description = raw_fields.get("description")
+        if isinstance(issue.fields.description, str):
+            description = issue.fields.description
+        elif raw_description:
+            description = extract_text_from_adf(raw_description)
+        else:
+            description = ""
+
+        # Extract comments distinguishing internal agent notes
+        comments = get_jsm_comment_strs(
+            issue=issue,
+            comment_email_blacklist=self.comment_email_blacklist,
+            include_internal_comments=self.include_internal_comments,
+        )
+
+        # Extract JSM-specific metadata
+        request_type = extract_customer_request_type(issue)
+        organizations = extract_organizations(issue)
+        sla_info = extract_sla_info(issue)
+
+        # Build content text
+        content_parts = []
+        if request_type:
+            content_parts.append(f"Request Type: {request_type}")
+        if organizations:
+            content_parts.append(f"Organizations: {', '.join(organizations)}")
+        if sla_info:
+            sla_strs = [f"{name}: {status}" for name, status in sla_info.items()]
+            content_parts.append(f"SLAs: {'; '.join(sla_strs)}")
+
+        if description:
+            content_parts.append(f"\nDescription:\n{description}")
+
+        if comments:
+            comments_text = "\n".join(f"Comment: {c}" for c in comments if c)
+            content_parts.append(f"\nComments:\n{comments_text}")
+
+        ticket_content = "\n".join(content_parts).strip()
+
+        # Check ticket size
+        if len(ticket_content.encode("utf-8")) > JIRA_CONNECTOR_MAX_TICKET_SIZE:
+            logger.info(
+                "Skipping %s because it exceeds the maximum size of %s bytes.",
+                issue.key,
+                JIRA_CONNECTOR_MAX_TICKET_SIZE,
+            )
+            return None
+
+        page_url = build_jira_url(self.jira_base, issue.key)
+
+        metadata_dict: dict[str, Any] = {}
+        people = set()
+
+        creator = best_effort_get_field_from_issue(issue, _FIELD_REPORTER)
+        if creator is not None and (
+            basic_expert_info := best_effort_basic_expert_info(creator)
+        ):
+            people.add(basic_expert_info)
+            metadata_dict[_FIELD_REPORTER] = basic_expert_info.get_semantic_name()
+            if email := basic_expert_info.get_email():
+                metadata_dict[_FIELD_REPORTER_EMAIL] = email
+
+        assignee = best_effort_get_field_from_issue(issue, _FIELD_ASSIGNEE)
+        if assignee is not None and (
+            basic_expert_info := best_effort_basic_expert_info(assignee)
+        ):
+            people.add(basic_expert_info)
+            metadata_dict[_FIELD_ASSIGNEE] = basic_expert_info.get_semantic_name()
+            if email := basic_expert_info.get_email():
+                metadata_dict[_FIELD_ASSIGNEE_EMAIL] = email
+
+        metadata_dict[_FIELD_KEY] = issue.key
+        if priority := best_effort_get_field_from_issue(issue, _FIELD_PRIORITY):
+            metadata_dict[_FIELD_PRIORITY] = (
+                priority.name if hasattr(priority, "name") else str(priority)
+            )
+        if status := best_effort_get_field_from_issue(issue, _FIELD_STATUS):
+            metadata_dict[_FIELD_STATUS] = (
+                status.name if hasattr(status, "name") else str(status)
+            )
+        if resolution := best_effort_get_field_from_issue(issue, _FIELD_RESOLUTION):
+            metadata_dict[_FIELD_RESOLUTION] = (
+                resolution.name if hasattr(resolution, "name") else str(resolution)
+            )
+        if labels := best_effort_get_field_from_issue(issue, _FIELD_LABELS):
+            metadata_dict[_FIELD_LABELS] = labels
+        if created := best_effort_get_field_from_issue(issue, _FIELD_CREATED):
+            metadata_dict[_FIELD_CREATED] = created
+        if updated := best_effort_get_field_from_issue(issue, _FIELD_UPDATED):
+            metadata_dict[_FIELD_UPDATED] = updated
+        if duedate := best_effort_get_field_from_issue(issue, _FIELD_DUEDATE):
+            metadata_dict[_FIELD_DUEDATE] = duedate
+        if issuetype := best_effort_get_field_from_issue(issue, _FIELD_ISSUETYPE):
+            metadata_dict[_FIELD_ISSUETYPE] = (
+                issuetype.name if hasattr(issuetype, "name") else str(issuetype)
+            )
+        if resolutiondate := best_effort_get_field_from_issue(
+            issue, _FIELD_RESOLUTION_DATE
+        ):
+            metadata_dict[_FIELD_RESOLUTION_DATE_KEY] = resolutiondate
+
+        parent = best_effort_get_field_from_issue(issue, _FIELD_PARENT)
+        if parent is not None:
+            metadata_dict[_FIELD_PARENT] = (
+                parent.key if hasattr(parent, "key") else str(parent)
+            )
+
+        project = best_effort_get_field_from_issue(issue, _FIELD_PROJECT)
+        if project is not None:
+            metadata_dict[_FIELD_PROJECT_NAME] = getattr(
+                project, "name", self.jira_project
+            )
+            metadata_dict[_FIELD_PROJECT] = getattr(project, "key", self.jira_project)
+        elif self.jira_project:
+            metadata_dict[_FIELD_PROJECT] = self.jira_project
+            metadata_dict[_FIELD_PROJECT_NAME] = self.jira_project
+
+        # Populate JSM specific metadata
+        if request_type:
+            metadata_dict[FIELD_CUSTOMER_REQUEST_TYPE] = request_type
+        if organizations:
+            metadata_dict[FIELD_ORGANIZATIONS] = organizations
+        if sla_info:
+            metadata_dict[FIELD_SLA_STATUS] = [
+                f"{name}: {status}" for name, status in sla_info.items()
+            ]
+
+        summary = getattr(issue.fields, "summary", issue.key)
+
+        return Document(
+            id=page_url,
+            sections=[TextSection(link=page_url, text=ticket_content)],
+            source=DocumentSource.JIRA_SERVICE_MANAGEMENT,
+            semantic_identifier=f"[{self.jira_project}] {issue.key}: {summary}",
+            title=f"[{issue.key}] {summary}",
+            doc_updated_at=time_str_to_utc(issue.fields.updated)
+            if hasattr(issue.fields, "updated") and issue.fields.updated
+            else None,
+            doc_created_at=time_str_to_utc(issue.fields.created)
+            if hasattr(issue.fields, "created") and issue.fields.created
+            else None,
+            primary_owners=list(people) or None,
+            metadata=metadata_dict,
+            parent_hierarchy_raw_node_id=parent_hierarchy_raw_node_id,
+        )

--- a/backend/onyx/connectors/jira_service_management/utils.py
+++ b/backend/onyx/connectors/jira_service_management/utils.py
@@ -1,0 +1,170 @@
+import logging
+from typing import Any
+
+from jira.resources import Issue
+
+from onyx.connectors.jira.utils import (
+    best_effort_get_field_from_issue,
+    extract_text_from_adf,
+)
+
+logger = logging.getLogger(__name__)
+
+# JSM-specific metadata field keys
+FIELD_CUSTOMER_REQUEST_TYPE = "customer_request_type"
+FIELD_ORGANIZATIONS = "organizations"
+FIELD_SLA_STATUS = "sla_status"
+
+
+def extract_customer_request_type(issue: Issue) -> str | None:
+    """Extracts the Customer Request Type from a Jira Service Management issue.
+
+    In Jira Cloud / Server JSM, request type may be stored in a custom field
+    object (e.g. {'requestType': {'name': '...'}, ...}) or string.
+    """
+    raw_fields: dict[str, Any] = getattr(issue, "raw", {}).get("fields", {})
+
+    for key, val in raw_fields.items():
+        if val is None:
+            continue
+        # Direct dictionary containing requestType or request type name
+        if isinstance(val, dict):
+            if "requestType" in val and isinstance(val["requestType"], dict):
+                req_name = val["requestType"].get("name")
+                if req_name:
+                    return str(req_name)
+            if "name" in val and "serviceDeskId" in val:
+                return str(val["name"])
+        # Custom field with key naming
+        if "request" in key.lower() and "type" in key.lower() and isinstance(val, str):
+            return val
+
+    # Fallback to standard issuetype name if distinct
+    issuetype = best_effort_get_field_from_issue(issue, "issuetype")
+    if issuetype and hasattr(issuetype, "name"):
+        return str(issuetype.name)
+
+    return None
+
+
+def extract_organizations(issue: Issue) -> list[str]:
+    """Extracts customer organizations associated with the JSM issue."""
+    # First check fields.organizations
+    if hasattr(issue, "fields") and hasattr(issue.fields, "organizations"):
+        orgs = getattr(issue.fields, "organizations")
+        if isinstance(orgs, list):
+            res = []
+            for item in orgs:
+                if isinstance(item, dict) and "name" in item:
+                    res.append(str(item["name"]))
+                elif hasattr(item, "name"):
+                    res.append(str(item.name))
+                elif isinstance(item, str):
+                    res.append(item)
+            if res:
+                return sorted(list(set(res)))
+
+    raw_fields: dict[str, Any] = getattr(issue, "raw", {}).get("fields", {})
+    org_names: list[str] = []
+
+    for key, val in raw_fields.items():
+        if not val:
+            continue
+        if ("organization" in key.lower() or key == "organizations") and isinstance(val, list):
+            for item in val:
+                if isinstance(item, dict) and "name" in item:
+                    org_names.append(str(item["name"]))
+                elif isinstance(item, str):
+                    org_names.append(item)
+
+    return sorted(list(set(org_names)))
+
+
+def extract_sla_info(issue: Issue) -> dict[str, str]:
+    """Extracts SLA metrics (e.g., Time to first response, Time to resolution).
+
+    Returns a mapping from SLA name to a status description (e.g. 'Breached', 'Met', 'In Progress').
+    """
+    raw_fields: dict[str, Any] = getattr(issue, "raw", {}).get("fields", {})
+    slas: dict[str, str] = {}
+
+    for _, val in raw_fields.items():
+        if not isinstance(val, dict):
+            continue
+        # JSM SLA fields typically have 'ongoingCycle' or 'completedCycles'
+        if "ongoingCycle" in val or "completedCycles" in val:
+            sla_name = val.get("name")
+            if not sla_name:
+                continue
+
+            ongoing = val.get("ongoingCycle")
+            if ongoing and isinstance(ongoing, dict):
+                breached = ongoing.get("breached", False)
+                slas[str(sla_name)] = "Breached" if breached else "In Progress"
+                continue
+
+            completed = val.get("completedCycles")
+            if completed and isinstance(completed, list) and completed:
+                last_cycle = completed[-1]
+                if isinstance(last_cycle, dict):
+                    breached = last_cycle.get("breached", False)
+                    slas[str(sla_name)] = "Breached" if breached else "Met"
+                    continue
+
+    return slas
+
+
+def get_jsm_comment_strs(
+    issue: Issue,
+    comment_email_blacklist: tuple[str, ...] = (),
+    include_internal_comments: bool = True,
+) -> list[str]:
+    """Processes comments for Jira Service Management.
+
+    Detects internal agent-only notes vs public customer comments.
+    If include_internal_comments is True, tags internal comments with '[Internal Note]'.
+    If False, excludes internal comments.
+    """
+    if not hasattr(issue, "fields") or not hasattr(issue.fields, "comment"):
+        return []
+
+    comment_strs: list[str] = []
+    comments = getattr(issue.fields.comment, "comments", [])
+
+    for comment in comments:
+        try:
+            # Check author against email blacklist
+            if (
+                hasattr(comment, "author")
+                and hasattr(comment.author, "emailAddress")
+                and comment.author.emailAddress in comment_email_blacklist
+            ):
+                continue
+
+            # Extract body text
+            if isinstance(comment.body, str):
+                body_text = comment.body
+            elif hasattr(comment, "raw") and "body" in comment.raw:
+                body_text = extract_text_from_adf(comment.raw["body"])
+            else:
+                body_text = str(getattr(comment, "body", ""))
+
+            if not body_text.strip():
+                continue
+
+            # Determine if comment is internal
+            raw_comment = getattr(comment, "raw", {})
+            # Atlassian JSM jsdPublic: False means internal note
+            is_public = raw_comment.get("jsdPublic", True)
+
+            if not is_public:
+                if not include_internal_comments:
+                    continue
+                body_text = f"[Internal Note] {body_text}"
+
+            comment_strs.append(body_text)
+        except Exception as e:
+            logger.error("Failed to process JSM comment: %s", e)
+            continue
+
+    return comment_strs

--- a/backend/onyx/connectors/registry.py
+++ b/backend/onyx/connectors/registry.py
@@ -60,6 +60,10 @@ CONNECTOR_CLASS_MAP = {
         module_path="onyx.connectors.jira.connector",
         class_name="JiraConnector",
     ),
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: ConnectorMapping(
+        module_path="onyx.connectors.jira_service_management.connector",
+        class_name="JiraServiceManagementConnector",
+    ),
     DocumentSource.PRODUCTBOARD: ConnectorMapping(
         module_path="onyx.connectors.productboard.connector",
         class_name="ProductboardConnector",

--- a/backend/onyx/onyxbot/slack/icons.py
+++ b/backend/onyx/onyxbot/slack/icons.py
@@ -19,6 +19,7 @@ _SOURCE_IMAGE_FILENAMES: Mapping[DocumentSource, str] = {
     DocumentSource.OUTLINE: "Outline.png",
     DocumentSource.CONFLUENCE: "Confluence.png",
     DocumentSource.JIRA: "Jira.png",
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: "Jira.png",
     DocumentSource.SLAB: "Slab.png",
     DocumentSource.PRODUCTBOARD: "Productboard.png",
     DocumentSource.FILE: _DEFAULT_SOURCE_IMAGE_FILENAME,

--- a/backend/tests/daily/connectors/jira_service_management/test_jsm_basic.py
+++ b/backend/tests/daily/connectors/jira_service_management/test_jsm_basic.py
@@ -1,0 +1,78 @@
+import time
+from unittest.mock import patch
+
+import pytest
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.jira_service_management.connector import (
+    JiraServiceManagementConnector,
+)
+from onyx.connectors.models import Document
+from tests.daily.connectors.utils import load_all_from_connector
+from tests.utils.secret_names import TestSecret
+
+pytestmark = pytest.mark.secrets(
+    TestSecret.JIRA_USER_EMAIL,
+    TestSecret.JIRA_API_TOKEN,
+    TestSecret.JIRA_API_TOKEN_SCOPED,
+)
+
+
+def _make_connector(
+    test_secrets: dict[TestSecret, str],
+    project_key: str = "ITSM",
+    scoped_token: bool = False,
+) -> JiraServiceManagementConnector:
+    connector = JiraServiceManagementConnector(
+        jira_base_url="https://danswerai.atlassian.net",
+        project_key=project_key,
+        comment_email_blacklist=[],
+        scoped_token=scoped_token,
+    )
+    connector.load_credentials(
+        {
+            "jira_user_email": test_secrets[TestSecret.JIRA_USER_EMAIL],
+            "jira_api_token": (
+                test_secrets[TestSecret.JIRA_API_TOKEN_SCOPED]
+                if scoped_token
+                else test_secrets[TestSecret.JIRA_API_TOKEN]
+            ),
+        }
+    )
+    return connector
+
+
+@pytest.fixture
+def jsm_connector(
+    test_secrets: dict[TestSecret, str],
+) -> JiraServiceManagementConnector:
+    return _make_connector(test_secrets)
+
+
+@patch(
+    "onyx.file_processing.extract_file_text.get_unstructured_api_key",
+    return_value=None,
+)
+def test_jsm_connector_basic(
+    reset: None,  # noqa: ARG001
+    jsm_connector: JiraServiceManagementConnector,
+) -> None:
+    _test_jsm_connector_basic(jsm_connector)
+
+
+def _test_jsm_connector_basic(
+    jsm_connector: JiraServiceManagementConnector,
+) -> None:
+    docs = load_all_from_connector(
+        connector=jsm_connector,
+        start=0,
+        end=time.time(),
+    ).documents
+
+    assert len(docs) > 0, "No documents were retrieved from the Jira Service Management connector"
+
+    for doc in docs:
+        assert isinstance(doc, Document)
+        assert doc.source == DocumentSource.JIRA_SERVICE_MANAGEMENT
+        assert doc.metadata.get("project") == jsm_connector.jira_project
+        assert doc.id.startswith(jsm_connector.jira_base)

--- a/backend/tests/unit/onyx/connectors/jira_service_management/conftest.py
+++ b/backend/tests/unit/onyx/connectors/jira_service_management/conftest.py
@@ -1,0 +1,142 @@
+from typing import Any
+from unittest.mock import MagicMock
+import pytest
+from jira.resources import Issue
+
+from onyx.connectors.jira_service_management.connector import (
+    JiraServiceManagementConnector,
+)
+
+
+class MockUser:
+    def __init__(self, display_name: str, email: str | None = None) -> None:
+        self.displayName = display_name
+        if email:
+            self.emailAddress = email
+
+
+class MockComment:
+    def __init__(
+        self, body: str, author: MockUser, is_public: bool = True
+    ) -> None:
+        self.body = body
+        self.author = author
+        self.raw = {"body": body, "jsdPublic": is_public}
+
+
+def make_mock_jsm_issue(
+    key: str = "ITSM-101",
+    summary: str = "VPN Connection Issue",
+    description: str = "Unable to connect to the corporate VPN from remote office.",
+    project_key: str = "ITSM",
+    project_name: str = "IT Service Desk",
+    request_type: str = "Get IT help",
+    organizations: list[str] | None = None,
+    slas: dict[str, Any] | None = None,
+    comments: list[MockComment] | None = None,
+    labels: list[str] | None = None,
+) -> Issue:
+    issue = MagicMock(spec=Issue)
+    issue.key = key
+
+    fields = MagicMock()
+    fields.summary = summary
+    fields.description = description
+    fields.labels = labels or ["vpn", "networking"]
+    fields.created = "2026-09-01T10:00:00.000+0000"
+    fields.updated = "2026-09-02T14:30:00.000+0000"
+    fields.duedate = "2026-09-05"
+    fields.resolutiondate = None
+
+    reporter = MockUser("Alice Requester", "alice@example.com")
+    assignee = MockUser("Bob Agent", "bob@example.com")
+    fields.reporter = reporter
+    fields.assignee = assignee
+
+    priority = MagicMock()
+    priority.name = "High"
+    fields.priority = priority
+
+    status = MagicMock()
+    status.name = "In Progress"
+    fields.status = status
+
+    fields.resolution = None
+
+    issuetype = MagicMock()
+    issuetype.name = "[System] Service Request"
+    fields.issuetype = issuetype
+
+    project = MagicMock()
+    project.key = project_key
+    project.name = project_name
+    fields.project = project
+
+    fields.parent = None
+
+    if comments is None:
+        comments = [
+            MockComment(
+                body="Please provide your operating system version.",
+                author=assignee,
+                is_public=True,
+            ),
+            MockComment(
+                body="Checked RADIUS logs, user certificate expired.",
+                author=assignee,
+                is_public=False,
+            ),
+        ]
+
+    comment_obj = MagicMock()
+    comment_obj.comments = comments
+    fields.comment = comment_obj
+
+    issue.fields = fields
+
+    # Mock raw representation for JSM fields
+    raw_fields: dict[str, Any] = {
+        "description": description,
+        "customfield_10010": {
+            "requestType": {"name": request_type},
+        },
+    }
+
+    if organizations:
+        raw_fields["organizations"] = [{"name": org} for org in organizations]
+
+    if slas:
+        raw_fields["customfield_10020"] = slas
+    else:
+        raw_fields["customfield_10020"] = {
+            "name": "Time to first response",
+            "completedCycles": [{"breached": False}],
+        }
+        raw_fields["customfield_10021"] = {
+            "name": "Time to resolution",
+            "ongoingCycle": {"breached": False},
+        }
+
+    issue.raw = {"fields": raw_fields}
+    return issue
+
+
+@pytest.fixture
+def mock_jira_client() -> MagicMock:
+    client = MagicMock()
+    proj = MagicMock()
+    proj.key = "ITSM"
+    proj.name = "IT Service Desk"
+    proj.projectTypeKey = "service_desk"
+    client.project.return_value = proj
+    return client
+
+
+@pytest.fixture
+def jsm_connector(mock_jira_client: MagicMock) -> JiraServiceManagementConnector:
+    connector = JiraServiceManagementConnector(
+        jira_base_url="https://support.example.com",
+        project_key="ITSM",
+    )
+    connector._jira_client = mock_jira_client
+    return connector

--- a/backend/tests/unit/onyx/connectors/jira_service_management/test_jsm_connector.py
+++ b/backend/tests/unit/onyx/connectors/jira_service_management/test_jsm_connector.py
@@ -1,0 +1,139 @@
+from unittest.mock import MagicMock, patch
+import pytest
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.exceptions import (
+    ConnectorValidationError,
+)
+from onyx.connectors.models import ConnectorMissingCredentialError
+from onyx.connectors.jira_service_management.connector import (
+    JiraServiceManagementConnector,
+)
+from tests.unit.onyx.connectors.jira_service_management.conftest import (
+    make_mock_jsm_issue,
+    MockComment,
+    MockUser,
+)
+
+
+def test_jsm_initialization() -> None:
+    connector = JiraServiceManagementConnector(
+        jira_base_url="https://support.example.com",
+        project_key="ITSM",
+        include_attachments=False,
+        include_internal_comments=True,
+    )
+    assert connector.jira_base == "https://support.example.com"
+    assert connector.jira_project == "ITSM"
+    assert connector.source == DocumentSource.JIRA_SERVICE_MANAGEMENT
+    assert connector.include_attachments is False
+    assert connector.include_internal_comments is True
+
+
+def test_jsm_validation_missing_credentials() -> None:
+    connector = JiraServiceManagementConnector(
+        jira_base_url="https://support.example.com",
+        project_key="ITSM",
+    )
+    with pytest.raises(ConnectorMissingCredentialError):
+        connector.validate_connector_settings()
+
+
+def test_jsm_validation_missing_project_key(mock_jira_client: MagicMock) -> None:
+    connector = JiraServiceManagementConnector(
+        jira_base_url="https://support.example.com",
+        project_key="",
+    )
+    connector._jira_client = mock_jira_client
+    with pytest.raises(ConnectorValidationError):
+        connector.validate_connector_settings()
+
+
+def test_jsm_validation_success(jsm_connector: JiraServiceManagementConnector) -> None:
+    # Should not raise
+    jsm_connector.validate_connector_settings()
+    jsm_connector.jira_client.project.assert_called_with("ITSM")
+
+
+def test_jsm_issue_processing_full_metadata(
+    jsm_connector: JiraServiceManagementConnector,
+) -> None:
+    issue = make_mock_jsm_issue(
+        organizations=["Acme Corp", "Beta LLC"],
+    )
+
+    doc = jsm_connector._process_issue(issue)
+    assert doc is not None
+
+    # Check basic document properties
+    assert doc.id == "https://support.example.com/browse/ITSM-101"
+    assert doc.source == DocumentSource.JIRA_SERVICE_MANAGEMENT
+    assert doc.semantic_identifier == "[ITSM] ITSM-101: VPN Connection Issue"
+    assert doc.title == "[ITSM-101] VPN Connection Issue"
+
+    # Check JSM metadata
+    assert doc.metadata["customer_request_type"] == "Get IT help"
+    assert doc.metadata["organizations"] == ["Acme Corp", "Beta LLC"]
+    assert "Time to first response: Met" in doc.metadata["sla_status"]
+    assert "Time to resolution: In Progress" in doc.metadata["sla_status"]
+    assert doc.metadata["reporter"] == "Alice Requester"
+    assert doc.metadata["reporter_email"] == "alice@example.com"
+    assert doc.metadata["assignee"] == "Bob Agent"
+    assert doc.metadata["assignee_email"] == "bob@example.com"
+    assert doc.metadata["project"] == "ITSM"
+    assert doc.metadata["project_name"] == "IT Service Desk"
+
+    # Check sections and content
+    assert len(doc.sections) == 1
+    section_text = doc.sections[0].text
+    assert "Request Type: Get IT help" in section_text
+    assert "Organizations: Acme Corp, Beta LLC" in section_text
+    assert "Time to first response: Met" in section_text
+    assert "Time to resolution: In Progress" in section_text
+    assert "Unable to connect to the corporate VPN from remote office." in section_text
+    # Internal comments should be marked with [Internal Note]
+    assert "[Internal Note] Checked RADIUS logs, user certificate expired." in section_text
+    assert "Please provide your operating system version." in section_text
+
+
+def test_jsm_issue_processing_exclude_internal_comments() -> None:
+    connector = JiraServiceManagementConnector(
+        jira_base_url="https://support.example.com",
+        project_key="ITSM",
+        include_internal_comments=False,
+    )
+    issue = make_mock_jsm_issue()
+    doc = connector._process_issue(issue)
+    assert doc is not None
+
+    section_text = doc.sections[0].text
+    # Public comment should be included
+    assert "Please provide your operating system version." in section_text
+    # Internal comment should be excluded
+    assert "Checked RADIUS logs, user certificate expired." not in section_text
+
+
+def test_jsm_issue_processing_skip_labels(
+    jsm_connector: JiraServiceManagementConnector,
+) -> None:
+    jsm_connector.labels_to_skip = {"sensitive", "internal_confidential"}
+    issue = make_mock_jsm_issue(labels=["vpn", "sensitive"])
+    doc = jsm_connector._process_issue(issue)
+    assert doc is None
+
+
+def test_jsm_slim_documents(jsm_connector: JiraServiceManagementConnector) -> None:
+    issue = make_mock_jsm_issue(key="ITSM-200", summary="Printer broken")
+
+    with patch(
+        "onyx.connectors.jira.connector._perform_jql_search",
+        return_value=[issue],
+    ):
+        slim_batches = list(
+            jsm_connector.retrieve_all_slim_docs(start=0, end=1000)
+        )
+        assert len(slim_batches) > 0
+        all_slim_ids = [
+            doc.id for batch in slim_batches for doc in batch if hasattr(doc, "id")
+        ]
+        assert "https://support.example.com/browse/ITSM-200" in all_slim_ids

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -862,6 +862,69 @@ export const connectorConfigs: Record<
     ],
     advanced_values: [],
   },
+  jira_service_management: {
+    description: "Configure Jira Service Management connector",
+    subtext: `Configure which Jira Service Management project to index. All customer requests, incidents, and service desk tickets will be ingested.`,
+    values: [
+      {
+        type: "text",
+        query: "Enter the Jira base URL:",
+        label: "Jira Base URL",
+        name: "jira_base_url",
+        optional: false,
+        description:
+          "The base URL of your Jira instance (e.g., https://your-domain.atlassian.net)",
+      },
+      {
+        type: "text",
+        query: "Enter the Service Management project key:",
+        label: "Project Key",
+        name: "project_key",
+        optional: false,
+        description:
+          "The project key of your Jira Service Management service desk (e.g., 'ITSM', 'HELP').",
+      },
+      {
+        type: "checkbox",
+        query: "Using scoped token?",
+        label: "Using scoped token",
+        name: "scoped_token",
+        optional: true,
+        default: false,
+      },
+      {
+        type: "checkbox",
+        query: "Include internal agent notes?",
+        label: "Include internal notes",
+        name: "include_internal_comments",
+        optional: true,
+        default: false,
+        description:
+          "Whether to index internal agent notes in addition to customer-visible comments.",
+      },
+      buildIncludeAttachmentsOption(false),
+      {
+        type: "list",
+        query: "Enter email addresses to blacklist from comments:",
+        label: "Comment Email Blacklist",
+        name: "comment_email_blacklist",
+        description:
+          "This is generally useful to ignore certain bots. Add user emails whose comments should NOT be indexed.",
+        optional: true,
+      },
+    ],
+    advanced_values: [
+      {
+        type: "text",
+        query: "Custom JQL filter (optional):",
+        label: "Custom JQL Query",
+        name: "jql_query",
+        optional: true,
+        description:
+          "Optional additional JQL filtering criteria (e.g., 'issuetype in (Incident, Problem)').",
+      },
+    ],
+  },
   salesforce: {
     description: "Configure Salesforce connector",
     values: [
@@ -2192,6 +2255,16 @@ export interface JiraConfig {
   project_key?: string;
   comment_email_blacklist?: string[];
   jql_query?: string;
+}
+
+export interface JiraServiceManagementConfig {
+  jira_base_url: string;
+  project_key: string;
+  scoped_token?: boolean;
+  comment_email_blacklist?: string[];
+  jql_query?: string;
+  include_attachments?: boolean;
+  include_internal_comments?: boolean;
 }
 
 export interface SalesforceConfig {

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -329,6 +329,7 @@ type CredentialTemplateMap = Record<ValidSources, object | null> & {
   outline: OutlineCredentialJson;
   confluence: ConfluenceCredentialJson;
   jira: JiraCredentialJson;
+  jira_service_management: JiraCredentialJson;
   productboard: ProductboardCredentialJson;
   slab: SlabCredentialJson;
   coda: CodaCredentialJson;
@@ -403,6 +404,10 @@ export const credentialTemplates: Record<ValidSources, any> = {
     confluence_access_token: "",
   },
   jira: {
+    jira_user_email: null,
+    jira_api_token: "",
+  },
+  jira_service_management: {
     jira_user_email: null,
     jira_api_token: "",
   },

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -264,6 +264,13 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     docs: `${DOCS_ADMINS_PATH}/connectors/official/jira`,
     isPopular: true,
   },
+  jira_service_management: {
+    icon: SvgJira,
+    displayName: "Jira Service Management",
+    category: SourceCategory.TicketingAndTaskManagement,
+    docs: `${DOCS_ADMINS_PATH}/connectors/official/jira_service_management`,
+    isPopular: true,
+  },
   zendesk: {
     icon: SvgZendesk,
     displayName: "Zendesk",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -609,6 +609,7 @@ export enum ValidSources {
   Outline = "outline",
   Confluence = "confluence",
   Jira = "jira",
+  JiraServiceManagement = "jira_service_management",
   Productboard = "productboard",
   Slab = "slab",
   Coda = "coda",
@@ -676,6 +677,7 @@ export const federatedSourceToRegularSource = (
 export const validAutoSyncSources = [
   ValidSources.Confluence,
   ValidSources.Jira,
+  ValidSources.JiraServiceManagement,
   ValidSources.GoogleDrive,
   ValidSources.Gmail,
   ValidSources.Slack,


### PR DESCRIPTION
/claim #2281
Resolves #2281

### Summary of Changes

Adds support for **Jira Service Management (JSM)** as a first-class connector in Onyx following the architectural guidelines outlined in `backend/onyx/connectors/README.md`.

#### Key Features & Implementation Details:
1. **Backend Integration**:
   - Added `DocumentSource.JIRA_SERVICE_MANAGEMENT = "jira_service_management"` to `backend/onyx/configs/constants.py` and updated source descriptions and Slack icon mappings.
   - Registered `JiraServiceManagementConnector` in `backend/onyx/connectors/registry.py` for dynamic lazy loading.
   - Added `JiraServiceManagementConnector` in `backend/onyx/connectors/jira_service_management/connector.py`, inheriting from `JiraConnector` to leverage pagination, checkpointing, and permissions sync while adding specialized JSM extraction.
   - Enriched ticket ingestion with:
     - **Customer Request Type** extraction (`FIELD_CUSTOMER_REQUEST_TYPE`).
     - **Customer Organizations** extraction (`FIELD_ORGANIZATIONS`).
     - **SLA Metrics** tracking (`FIELD_SLA_STATUS` e.g. Time to First Response, Time to Resolution with Met/Breached/In-Progress states).
     - **Internal Notes vs Public Comments**: Distinguishes agent internal notes (`[Internal Note]`) with a configurable toggle (`include_internal_comments`).
     - Standardized `include_attachments: bool = False` configuration option.

2. **Frontend UI & Forms**:
   - Registered `ValidSources.JiraServiceManagement` in `web/src/lib/types.ts`.
   - Added metadata to `SOURCE_METADATA_MAP` in `web/src/lib/sources.ts`.
   - Added connector configuration form in `web/src/lib/connectors/connectors.tsx` with fields for Base URL, Project Key, Scoped Token, Internal Notes toggle, Attachments toggle, and optional custom JQL query filter.
   - Added credential templates in `web/src/lib/connectors/credentials.ts`.

3. **Test Suite**:
   - Added comprehensive unit tests in `backend/tests/unit/onyx/connectors/jira_service_management/test_jsm_connector.py` verifying initialization, credentials validation, project key validation, metadata extraction, comment handling, and slim doc generation (8 passing tests).
   - Added daily connector test in `backend/tests/daily/connectors/jira_service_management/test_jsm_basic.py`.
   - Verified 100% pass rate across all 42 Jira/JSM unit tests.

---
**Payout Address (Base L2)**: `0x46D5318E4397cFcBED06a235c1604E473682Ea1F`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Jira Service Management (JSM) as a first-class connector, reusing the Jira connector's pagination, checkpointing, and permission handling while adding service-desk-specific ticket extraction.

**New Features**

- Registers `jira_service_management` as a new source backed by `JiraServiceManagementConnector`, which extends `JiraConnector`.
- Extracts customer request type, organizations, and SLA status (Met/Breached/In Progress) into document text and metadata.
- Distinguishes internal agent notes from public comments; `include_internal_comments` controls whether notes are indexed.
- Adds web config and credential forms with fields for base URL, project key, scoped token, internal notes, attachments, and an optional JQL filter.
- Adds unit and daily tests covering initialization, validation, metadata extraction, comment handling, and slim docs.

<sup>Written for commit 2271dce73ef0f13b0b9ffcee1a1ebb90702b39dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

