### PR TITLE
fix(persona): allowlist avatar upload content type

### DIFF
--- a/backend/onyx/file_processing/file_types.py
+++ b/backend/onyx/file_processing/file_types.py
@@ -57,6 +57,16 @@ class OnyxMimeTypes:
     }
 
 
+def is_allowed_avatar_content_type(content_type: str | None) -> bool:
+    """True when `content_type` is safe to store and later serve back as an
+    assistant/persona avatar image. `None` is allowed so callers can fall
+    back to a default file type; any other value must be one of the plain
+    raster image types, so a client cannot get `text/html` or
+    `image/svg+xml` stored (and later served inline) as the avatar's
+    content type."""
+    return content_type is None or content_type in OnyxMimeTypes.IMAGE_MIME_TYPES
+
+
 class OnyxFileExtensions:
     SPREADSHEET_EXTENSIONS = {
         ".xlsx",

--- a/backend/onyx/server/features/persona/api.py
+++ b/backend/onyx/server/features/persona/api.py
@@ -64,6 +64,7 @@ from onyx.db.persona_sharing import (
 from onyx.db.users import get_active_admin_count
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
+from onyx.file_processing.file_types import is_allowed_avatar_content_type
 from onyx.file_store.file_store import get_default_file_store
 from onyx.file_store.models import ChatFileType
 from onyx.server.documents.models import PaginatedReturn
@@ -327,6 +328,17 @@ def upload_file(
     file: UploadFile,
     _: User = Depends(require_permission(Permission.BASIC_ACCESS)),
 ) -> dict[str, str]:
+    # This endpoint only stores avatar images, so the client-supplied
+    # content type is checked against the image allowlist before it is
+    # stored. Without this, a value such as `text/html` or
+    # `image/svg+xml` is stored verbatim and later served back on the
+    # avatar route with that same content type.
+    if not is_allowed_avatar_content_type(file.content_type):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported avatar content type: {file.content_type}",
+        )
+
     file_store = get_default_file_store()
     file_type = ChatFileType.IMAGE
     file_id = file_store.save_file(
@@ -813,6 +825,10 @@ def get_persona_avatar(
         "Cache-Control": "private, max-age=31536000, immutable",
         "ETag": etag,
         "Vary": "Cookie",
+        # Belt-and-suspenders: the upload endpoint now rejects non-image
+        # content types, but this stops a browser from sniffing and
+        # rendering stored bytes as anything other than the declared type.
+        "X-Content-Type-Options": "nosniff",
     }
     if request.headers.get("if-none-match") == etag:
         return Response(status_code=304, headers=cache_headers)

--- a/backend/tests/unit/onyx/file_processing/test_file_types.py
+++ b/backend/tests/unit/onyx/file_processing/test_file_types.py
@@ -1,0 +1,28 @@
+from onyx.file_processing.file_types import is_allowed_avatar_content_type
+
+
+def test_allows_configured_raster_image_types() -> None:
+    assert is_allowed_avatar_content_type("image/png")
+    assert is_allowed_avatar_content_type("image/jpeg")
+    assert is_allowed_avatar_content_type("image/jpg")
+    assert is_allowed_avatar_content_type("image/webp")
+
+
+def test_allows_missing_content_type() -> None:
+    # Callers fall back to a default file type when the client sends none.
+    assert is_allowed_avatar_content_type(None)
+
+
+def test_rejects_html_content_type() -> None:
+    assert not is_allowed_avatar_content_type("text/html")
+
+
+def test_rejects_svg_content_type() -> None:
+    # SVG can carry inline <script>; it is deliberately excluded from
+    # OnyxMimeTypes.IMAGE_MIME_TYPES.
+    assert not is_allowed_avatar_content_type("image/svg+xml")
+
+
+def test_rejects_other_excluded_image_types() -> None:
+    assert not is_allowed_avatar_content_type("image/gif")
+    assert not is_allowed_avatar_content_type("image/bmp")


### PR DESCRIPTION
## Description

`POST /admin/persona/upload-image` stores the client-supplied `content_type` verbatim as the persona avatar's `file_type` (`backend/onyx/server/features/persona/api.py`, `upload_file()`). `GET /persona/{id}/avatar` serves that value back unchanged as the response `media_type` (same file, `get_persona_avatar()`). A caller can set `content_type` to `text/html` or `image/svg+xml` on upload, so the avatar route later serves those bytes with that content type, on a route browsers fetch directly (`<img src="/api/persona/{id}/avatar">`, and the URL can be opened directly too).

`onyx/file_processing/file_types.py` already defines `OnyxMimeTypes.IMAGE_MIME_TYPES` (`image/jpg`, `image/jpeg`, `image/png`, `image/webp`) and `EXCLUDED_IMAGE_TYPES` (lists `image/svg+xml`), used elsewhere to classify image content. The upload endpoint did not check against this allowlist.

This PR:

- Adds `is_allowed_avatar_content_type()` next to `OnyxMimeTypes` in `file_types.py`. Allows `None` (the endpoint already falls back to a default file type when no content type is sent) and any value in `IMAGE_MIME_TYPES`; rejects everything else.
- Calls it in `upload_file()`, raising `HTTPException(400)` for a rejected content type before the file reaches storage.
- Adds `X-Content-Type-Options: nosniff` to the response headers in `get_persona_avatar()`, as a second layer in case a stored `file_type` is ever anything other than the declared content type.

Deliberately not changed: the avatar route still serves `media_type=file_record.file_type` as-is, now constrained to the four allowed types by the upload-side check. `chat_backend.py:fetch_chat_file` has the same pattern for a different upload path, left for a separate change. PNG/JPEG/WEBP avatar uploads are unaffected. GIF, BMP, TIFF and AVIF avatars, previously accepted because the endpoint did not validate the content type at all, are now rejected with 400, consistent with `OnyxMimeTypes.IMAGE_MIME_TYPES`.

## How Has This Been Tested?

- `ruff check` and `ruff format --check` on all changed files: clean.
- `ty check` on `file_types.py`: clean. `ty check` on `api.py` reports 32 diagnostics, all pre-existing on unmodified `main` (confirmed via `git stash`), caused by this sandbox missing the full dependency install; none on the changed lines.
- Added `backend/tests/unit/onyx/file_processing/test_file_types.py` for `is_allowed_avatar_content_type()`: accepts the four image types and `None`, rejects `text/html`, `image/svg+xml`, `image/gif`, `image/bmp`. 5 passed. Reverting the `file_types.py` change makes this test file fail at collection, confirming it exercises the fix.
- The full backend suite was **not run**: no Docker, no full dependency install here. The existing integration test (`tests/integration/tests/personas/test_persona_avatar.py`) and Playwright spec (`persona_avatar.spec.ts`) upload with `content_type: "image/png"`, which stays allowed, so they should be unaffected; not verified by running them.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

### References

GHSA-jx43-8x73-xm5q ([found during penetration test](https://www.turingpoint.de/en/security-assessments/pentests/) by [turingpoint](https://www.turingpoint.de), reported privately, unpublished at time of writing)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts persona avatar uploads to the allowed raster image types so the avatar route can no longer serve stored bytes as `text/html` or `image/svg+xml`.

- `POST /admin/persona/upload-image` now rejects disallowed content types with a 400 before the file reaches storage.
- `GET /persona/{id}/avatar` now sends `X-Content-Type-Options: nosniff` as a second layer if an unexpected file type is ever stored.
- Existing GIF, BMP, TIFF, and AVIF avatars are now rejected on upload, consistent with `OnyxMimeTypes.IMAGE_MIME_TYPES`; PNG, JPEG, JPG, and WebP uploads are unaffected.

<sup>Written for commit 55d4dbbe3be9857a622a15d384cd3e2ccad3a2ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

