### PR TITLE
feat: Jira Service Management connector

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -259,6 +259,7 @@ class DocumentSource(str, Enum):
     OUTLINE = "outline"
     CONFLUENCE = "confluence"
     JIRA = "jira"
+    JIRA_SERVICE_MANAGEMENT = "jira_service_management"
     SLAB = "slab"
     PRODUCTBOARD = "productboard"
     FILE = "file"
@@ -781,6 +782,7 @@ DocumentSourceDescription: dict[DocumentSource, str] = {
     DocumentSource.OUTLINE: "Documentation and knowledge base pages",
     DocumentSource.CONFLUENCE: "Wiki pages, spaces, and documentation",
     DocumentSource.JIRA: "Issues, tickets, and project tracking",
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: "Customer service requests and service desk tickets",
     DocumentSource.SLAB: "Documentation and knowledge base pages",
     DocumentSource.PRODUCTBOARD: "Product management boards and insights",
     DocumentSource.FILE: "Uploaded files",

--- a/backend/onyx/connectors/jira/connector.py
+++ b/backend/onyx/connectors/jira/connector.py
@@ -3,7 +3,7 @@ import json
 import os
 from collections.abc import Callable, Generator, Iterable, Iterator
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Any, ClassVar
 
 import requests
 from jira import JIRA
@@ -389,12 +389,32 @@ def _perform_jql_search_v2(
             raise RuntimeError(f"Found Jira object not of type Issue: {issue}")
 
 
+def _extract_issue_comments(
+    issue: Issue,
+    comment_email_blacklist: tuple[str, ...],
+    comment_extractor: Callable[[Issue], list[str]] | None,
+) -> list[str]:
+    """Extract comment text, honoring a caller-supplied extractor.
+
+    Callers with source-specific comment semantics (e.g. Jira Service
+    Management internal notes) can supply their own extractor.
+    """
+    if comment_extractor is not None:
+        return comment_extractor(issue)
+    return get_comment_strs(
+        issue=issue,
+        comment_email_blacklist=comment_email_blacklist,
+    )
+
+
 def process_jira_issue(
     jira_base_url: str,
     issue: Issue,
     comment_email_blacklist: tuple[str, ...] = (),
     labels_to_skip: set[str] | None = None,
     parent_hierarchy_raw_node_id: str | None = None,
+    source: DocumentSource = DocumentSource.JIRA,
+    comment_extractor: Callable[[Issue], list[str]] | None = None,
 ) -> Document | None:
     if labels_to_skip:
         if any(label in issue.fields.labels for label in labels_to_skip):
@@ -411,9 +431,10 @@ def process_jira_issue(
     else:
         description = extract_text_from_adf(issue.raw["fields"]["description"])
 
-    comments = get_comment_strs(
+    comments = _extract_issue_comments(
         issue=issue,
         comment_email_blacklist=comment_email_blacklist,
+        comment_extractor=comment_extractor,
     )
     ticket_content = f"{description}\n" + "\n".join(
         [f"Comment: {comment}" for comment in comments if comment]
@@ -487,7 +508,7 @@ def process_jira_issue(
     return Document(
         id=page_url,
         sections=[TextSection(link=page_url, text=ticket_content)],
-        source=DocumentSource.JIRA,
+        source=source,
         semantic_identifier=f"{issue.key}: {issue.fields.summary}",
         title=f"{issue.key} {issue.fields.summary}",
         doc_updated_at=time_str_to_utc(issue.fields.updated),
@@ -516,6 +537,11 @@ class JiraConnector(
     SlimConnector,
     SlimConnectorWithPermSync,
 ):
+    # Source stamped onto every document produced by this connector. Overridable
+    # so specialized connectors (e.g. Jira Service Management) can reuse the
+    # indexing machinery while branding documents as their own source.
+    document_source: ClassVar[DocumentSource] = DocumentSource.JIRA
+
     def __init__(
         self,
         jira_base_url: str,
@@ -703,6 +729,25 @@ class JiraConnector(
         # the document belongs directly under the project in the hierarchy
         return project_key
 
+    def _process_issue(
+        self,
+        issue: Issue,
+        parent_hierarchy_raw_node_id: str | None = None,
+    ) -> Document | None:
+        """Convert a single issue into a Document.
+
+        Overridable hook for specialized connectors to adjust comment
+        handling and metadata enrichment.
+        """
+        return process_jira_issue(
+            jira_base_url=self.jira_base,
+            issue=issue,
+            comment_email_blacklist=self.comment_email_blacklist,
+            labels_to_skip=self.labels_to_skip,
+            parent_hierarchy_raw_node_id=parent_hierarchy_raw_node_id,
+            source=self.document_source,
+        )
+
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
         self._jira_client = build_jira_client(
             credentials=credentials,
@@ -827,11 +872,8 @@ class JiraConnector(
                     else None
                 )
 
-                if document := process_jira_issue(
-                    jira_base_url=self.jira_base,
+                if document := self._process_issue(
                     issue=issue,
-                    comment_email_blacklist=self.comment_email_blacklist,
-                    labels_to_skip=self.labels_to_skip,
                     parent_hierarchy_raw_node_id=parent_hierarchy_raw_node_id,
                 ):
                     # Add permission information to the document if requested

--- a/backend/onyx/connectors/jira_service_management/__init__.py
+++ b/backend/onyx/connectors/jira_service_management/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for Jira Service Management connector

--- a/backend/onyx/connectors/jira_service_management/connector.py
+++ b/backend/onyx/connectors/jira_service_management/connector.py
@@ -1,0 +1,206 @@
+from typing import Any, ClassVar
+
+from jira.resources import Issue
+
+from onyx.configs.app_configs import (
+    INDEX_BATCH_SIZE,
+    JIRA_CONNECTOR_LABELS_TO_SKIP,
+)
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.exceptions import ConnectorValidationError
+from onyx.connectors.jira.connector import (
+    JiraConnector,
+    _perform_jql_search,
+    process_jira_issue,
+)
+from onyx.connectors.jira_service_management.utils import (
+    JsmFieldMap,
+    build_jsm_metadata,
+    discover_jsm_fields,
+    get_jsm_comment_strs,
+)
+from onyx.connectors.models import ConnectorMissingCredentialError, Document
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+class JiraServiceManagementConnector(JiraConnector):
+    """Indexes all tickets from a specified Jira Service Management project.
+
+    JSM is backed by the same Jira REST API as regular Jira, so this connector
+    subclasses the Jira connector (checkpointed pagination, slim docs, hierarchy
+    and permission sync all carry over) and specializes:
+
+    - document source branding (``DocumentSource.JIRA_SERVICE_MANAGEMENT``)
+    - comment handling: JSM internal agent notes (``jsdPublic`` comments) are
+      excluded unless ``include_internal_comments`` is set, in which case they
+      are tagged with an ``[Internal Note]`` prefix
+    - JSM specific metadata: customer request type, organizations and SLA
+      statuses, discovered by field name so no instance-specific field IDs are
+      hard-coded
+    - settings validation: a service desk project key is required and the
+      project must be a JSM (``service_desk``) project
+    """
+
+    document_source: ClassVar[DocumentSource] = DocumentSource.JIRA_SERVICE_MANAGEMENT
+
+    def __init__(
+        self,
+        jira_base_url: str,
+        project_key: str,
+        comment_email_blacklist: list[str] | None = None,
+        batch_size: int = INDEX_BATCH_SIZE,
+        labels_to_skip: list[str] = JIRA_CONNECTOR_LABELS_TO_SKIP,
+        jql_query: str | None = None,
+        scoped_token: bool = False,
+        include_internal_comments: bool = False,
+    ) -> None:
+        super().__init__(
+            jira_base_url=jira_base_url,
+            project_key=project_key,
+            comment_email_blacklist=comment_email_blacklist,
+            batch_size=batch_size,
+            labels_to_skip=labels_to_skip,
+            jql_query=jql_query,
+            scoped_token=scoped_token,
+        )
+        self.include_internal_comments = include_internal_comments
+        self._jsm_field_map: JsmFieldMap | None = None
+
+    @property
+    def jsm_field_map(self) -> JsmFieldMap:
+        """JSM field IDs, discovered lazily and cached for the connector's lifetime."""
+        if self._jsm_field_map is None:
+            self._jsm_field_map = discover_jsm_fields(self.jira_client)
+        return self._jsm_field_map
+
+    def _process_issue(
+        self,
+        issue: Issue,
+        parent_hierarchy_raw_node_id: str | None = None,
+    ) -> Document | None:
+        document = process_jira_issue(
+            jira_base_url=self.jira_base,
+            issue=issue,
+            comment_email_blacklist=self.comment_email_blacklist,
+            labels_to_skip=self.labels_to_skip,
+            parent_hierarchy_raw_node_id=parent_hierarchy_raw_node_id,
+            source=self.document_source,
+            comment_extractor=lambda issue: get_jsm_comment_strs(
+                issue=issue,
+                comment_email_blacklist=self.comment_email_blacklist,
+                include_internal_comments=self.include_internal_comments,
+            ),
+        )
+        if document is None:
+            return None
+
+        # Enrichment is best effort: a failure to extract JSM metadata should
+        # not lose the ticket itself.
+        try:
+            document.metadata.update(build_jsm_metadata(issue, self.jsm_field_map))
+        except Exception:
+            logger.exception(
+                "Failed to extract JSM metadata for %s; continuing without it.",
+                issue.key,
+            )
+        return document
+
+    @staticmethod
+    def _best_effort_project_type(project: Any) -> str | None:
+        project_type = getattr(project, "projectTypeKey", None)
+        if isinstance(project_type, str) and project_type:
+            return project_type
+        raw = getattr(project, "raw", None)
+        if isinstance(raw, dict):
+            raw_type = raw.get("projectTypeKey")
+            if isinstance(raw_type, str) and raw_type:
+                return raw_type
+        return None
+
+    def validate_connector_settings(self) -> None:
+        if self._jira_client is None:
+            raise ConnectorMissingCredentialError("Jira Service Management")
+
+        # A JSM project key is mandatory; the general-purpose Jira connector is
+        # the right tool for indexing everything a credential can access.
+        if not self.jira_project or not self.jira_project.strip():
+            raise ConnectorValidationError(
+                "A Jira Service Management project key is required."
+            )
+
+        try:
+            project = self.jira_client.project(self.jira_project)
+        except Exception as e:
+            self._handle_jira_connector_settings_error(e)
+            raise  # _handle_jira_connector_settings_error always raises
+
+        # Enforce that the project actually is a service desk project. Only
+        # checked when the project type is exposed by the instance.
+        project_type = self._best_effort_project_type(project)
+        if project_type is not None and project_type != "service_desk":
+            raise ConnectorValidationError(
+                f"Project '{self.jira_project}' is a '{project_type}' project, but "
+                "the Jira Service Management connector requires a service desk "
+                "project (projectTypeKey == 'service_desk'). Use the Jira "
+                "connector for traditional Jira projects."
+            )
+
+        # If a custom JQL query is set, validate it's valid
+        if self.jql_query:
+            try:
+                next(
+                    iter(
+                        _perform_jql_search(
+                            jira_client=self.jira_client,
+                            jql=self.jql_query,
+                            start=0,
+                            max_results=1,
+                            all_issue_ids=[],
+                        )
+                    ),
+                    None,
+                )
+            except Exception as e:
+                self._handle_jira_connector_settings_error(e)
+
+
+if __name__ == "__main__":
+    import os
+    from datetime import datetime
+
+    from onyx.utils.variable_functionality import global_version
+    from tests.daily.connectors.utils import load_all_from_connector
+
+    # For connector permission testing, set EE to true.
+    global_version.set_ee()
+
+    connector = JiraServiceManagementConnector(
+        jira_base_url=os.environ["JSM_BASE_URL"],
+        project_key=os.environ["JSM_PROJECT_KEY"],
+        comment_email_blacklist=[],
+    )
+
+    connector.load_credentials(
+        {
+            "jira_user_email": os.environ["JIRA_USER_EMAIL"],
+            "jira_api_token": os.environ["JIRA_API_TOKEN"],
+        }
+    )
+
+    start = 0
+    end = datetime.now().timestamp()
+
+    for slim_doc in connector.retrieve_all_slim_docs_perm_sync(
+        start=start,
+        end=end,
+    ):
+        print(slim_doc)
+
+    for doc in load_all_from_connector(
+        connector=connector,
+        start=start,
+        end=end,
+    ).documents:
+        print(doc)

--- a/backend/onyx/connectors/jira_service_management/utils.py
+++ b/backend/onyx/connectors/jira_service_management/utils.py
@@ -1,0 +1,274 @@
+"""Helpers for Jira Service Management (JSM) specific issue fields.
+
+JSM stores its domain data (customer request type, organizations, SLAs) in
+custom fields whose IDs (``customfield_XXXXX``) differ between Jira instances.
+The field *display names* are stable though, so IDs are discovered by name at
+runtime and extraction falls back to structural value detection when discovery
+is unavailable. Nothing here is instance-specific.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+from jira import JIRA
+from jira.resources import Issue
+
+from onyx.connectors.jira.utils import extract_text_from_adf
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# Metadata keys stamped onto the resulting Document
+FIELD_CUSTOMER_REQUEST_TYPE = "customer_request_type"
+FIELD_ORGANIZATIONS = "organizations"
+FIELD_SLA_STATUS = "sla_status"
+
+# JSM custom fields identified by their (stable) display names.
+CUSTOMER_REQUEST_TYPE_FIELD_NAME = "Customer Request Type"
+ORGANIZATIONS_FIELD_NAME = "Organizations"
+
+# Regardless of the instance-specific field ID or the admin-defined SLA name,
+# SLA field values always carry one of these keys.
+_SLA_KEYS = ("ongoingCycle", "completedCycles")
+
+
+@dataclass
+class JsmFieldMap:
+    """Best-effort mapping of JSM field names to instance-specific field IDs."""
+
+    customer_request_type: str | None = None
+    organizations: str | None = None
+
+
+def discover_jsm_fields(jira_client: JIRA) -> JsmFieldMap:
+    """Discover JSM custom field IDs by their display names.
+
+    Best effort: if the fields endpoint is unavailable, an empty map is
+    returned and the extractors fall back to structural value detection.
+    """
+    try:
+        all_fields = jira_client.fields()
+    except Exception:
+        logger.warning(
+            "Unable to list Jira fields for JSM field discovery; "
+            "falling back to structural detection."
+        )
+        return JsmFieldMap()
+
+    field_map = JsmFieldMap()
+    for field in all_fields:
+        try:
+            name = field.get("name")
+            field_id = field.get("id")
+        except AttributeError:
+            continue
+        if not name or not field_id:
+            continue
+        if name == CUSTOMER_REQUEST_TYPE_FIELD_NAME:
+            field_map.customer_request_type = field_id
+        elif name == ORGANIZATIONS_FIELD_NAME:
+            field_map.organizations = field_id
+    return field_map
+
+
+def _get_raw_field(issue: Issue, field_id: str) -> Any:
+    try:
+        return issue.raw["fields"][field_id]
+    except (AttributeError, KeyError, TypeError):
+        return None
+
+
+def _raw_field_values(issue: Issue) -> list[Any]:
+    try:
+        raw_fields = issue.raw["fields"]
+    except (AttributeError, KeyError, TypeError):
+        return []
+    return list(raw_fields.values()) if isinstance(raw_fields, dict) else []
+
+
+def _name_from_request_type_value(value: dict[str, Any]) -> str | None:
+    request_type = value.get("requestType")
+    if isinstance(request_type, dict) and request_type.get("name"):
+        return str(request_type["name"])
+    # Some deployments return {"name": ..., "serviceDeskId": ...}
+    if value.get("name") and "serviceDeskId" in value:
+        return str(value["name"])
+    return None
+
+
+def extract_customer_request_type(
+    issue: Issue, field_id: str | None = None
+) -> str | None:
+    """Extract the JSM customer request type, best effort.
+
+    Jira Cloud returns a ``"<serviceDeskId>/<requestTypeId>"`` string for the
+    customer request type field; some deployments return an object with the
+    request type embedded. If field discovery failed, raw fields are scanned
+    for that object structure.
+    """
+    if field_id:
+        value = _get_raw_field(issue, field_id)
+        if isinstance(value, str) and value:
+            return value
+        if isinstance(value, dict):
+            name = _name_from_request_type_value(value)
+            if name:
+                return name
+
+    for value in _raw_field_values(issue):
+        if isinstance(value, dict):
+            name = _name_from_request_type_value(value)
+            if name:
+                return name
+    return None
+
+
+def _organization_names(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    names = []
+    for item in value:
+        if isinstance(item, dict) and item.get("name"):
+            names.append(str(item["name"]))
+        elif isinstance(item, str) and item:
+            names.append(item)
+    return names
+
+
+def _looks_like_organizations(value: Any) -> bool:
+    """JSM organization values are lists of ``{"id", "name"}`` dicts."""
+    if not isinstance(value, list) or not value:
+        return False
+    return all(
+        isinstance(item, dict)
+        and item.get("name")
+        and set(item.keys()) <= {"id", "name"}
+        for item in value
+    )
+
+
+def extract_organizations(issue: Issue, field_id: str | None = None) -> list[str]:
+    """Extract the names of the JSM organizations on the request, best effort."""
+    candidates: list[Any] = []
+    if field_id:
+        value = _get_raw_field(issue, field_id)
+        if value is not None:
+            candidates.append(value)
+
+    candidates.extend(
+        value for value in _raw_field_values(issue) if _looks_like_organizations(value)
+    )
+
+    for candidate in candidates:
+        names = _organization_names(candidate)
+        if names:
+            return names
+    return []
+
+
+def extract_sla_info(issue: Issue) -> dict[str, str]:
+    """Extract SLA statuses keyed by the admin-defined SLA name, best effort.
+
+    An ongoing cycle maps to "In Progress" (or "Breached"), the latest
+    completed cycle maps to "Met" (or "Breached").
+    """
+    slas: dict[str, str] = {}
+    for value in _raw_field_values(issue):
+        if not isinstance(value, dict) or not any(key in value for key in _SLA_KEYS):
+            continue
+        sla_name = value.get("name")
+        if not sla_name:
+            continue
+
+        ongoing = value.get("ongoingCycle")
+        if isinstance(ongoing, dict):
+            slas[str(sla_name)] = (
+                "Breached" if ongoing.get("breached") else "In Progress"
+            )
+            continue
+
+        completed_cycles = value.get("completedCycles")
+        if isinstance(completed_cycles, list) and completed_cycles:
+            last_cycle = completed_cycles[-1]
+            breached = (
+                last_cycle.get("breached", False)
+                if isinstance(last_cycle, dict)
+                else False
+            )
+            slas[str(sla_name)] = "Breached" if breached else "Met"
+    return slas
+
+
+def build_jsm_metadata(
+    issue: Issue, field_map: JsmFieldMap
+) -> dict[str, str | list[str]]:
+    """Build the JSM specific metadata entries for a ticket document."""
+    metadata: dict[str, str | list[str]] = {}
+
+    request_type = extract_customer_request_type(issue, field_map.customer_request_type)
+    if request_type:
+        metadata[FIELD_CUSTOMER_REQUEST_TYPE] = request_type
+
+    organizations = extract_organizations(issue, field_map.organizations)
+    if organizations:
+        metadata[FIELD_ORGANIZATIONS] = organizations
+
+    sla_info = extract_sla_info(issue)
+    if sla_info:
+        metadata[FIELD_SLA_STATUS] = [
+            f"{name}: {state}" for name, state in sorted(sla_info.items())
+        ]
+
+    return metadata
+
+
+def get_jsm_comment_strs(
+    issue: Issue,
+    comment_email_blacklist: tuple[str, ...] = (),
+    include_internal_comments: bool = False,
+) -> list[str]:
+    """Extract comment text with JSM internal-note awareness.
+
+    JSM comments carry a ``jsdPublic`` flag: ``False`` marks internal agent
+    notes that are not visible to customers. Internal notes are skipped unless
+    ``include_internal_comments`` is set; when included, they are tagged with
+    an ``[Internal Note]`` prefix so retrieval can distinguish them.
+    """
+    comment_strs: list[str] = []
+    try:
+        comments = issue.fields.comment.comments
+    except (AttributeError, TypeError):
+        return comment_strs
+
+    for comment in comments:
+        try:
+            if (
+                hasattr(comment, "author")
+                and hasattr(comment.author, "emailAddress")
+                and comment.author.emailAddress in comment_email_blacklist
+            ):
+                continue
+
+            if isinstance(comment.body, str):
+                body_text = comment.body
+            else:
+                body_text = extract_text_from_adf(comment.raw["body"])
+
+            if not body_text or not body_text.strip():
+                continue
+
+            raw_comment = getattr(comment, "raw", None)
+            is_internal = (
+                isinstance(raw_comment, dict) and raw_comment.get("jsdPublic") is False
+            )
+            if is_internal:
+                if not include_internal_comments:
+                    continue
+                body_text = f"[Internal Note] {body_text}"
+
+            comment_strs.append(body_text)
+        except Exception:
+            logger.exception("Failed to process JSM comment; skipping it.")
+            continue
+
+    return comment_strs

--- a/backend/onyx/connectors/registry.py
+++ b/backend/onyx/connectors/registry.py
@@ -60,6 +60,10 @@ CONNECTOR_CLASS_MAP = {
         module_path="onyx.connectors.jira.connector",
         class_name="JiraConnector",
     ),
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: ConnectorMapping(
+        module_path="onyx.connectors.jira_service_management.connector",
+        class_name="JiraServiceManagementConnector",
+    ),
     DocumentSource.PRODUCTBOARD: ConnectorMapping(
         module_path="onyx.connectors.productboard.connector",
         class_name="ProductboardConnector",

--- a/backend/onyx/onyxbot/slack/icons.py
+++ b/backend/onyx/onyxbot/slack/icons.py
@@ -19,6 +19,7 @@ _SOURCE_IMAGE_FILENAMES: Mapping[DocumentSource, str] = {
     DocumentSource.OUTLINE: "Outline.png",
     DocumentSource.CONFLUENCE: "Confluence.png",
     DocumentSource.JIRA: "Jira.png",
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: "Jira.png",
     DocumentSource.SLAB: "Slab.png",
     DocumentSource.PRODUCTBOARD: "Productboard.png",
     DocumentSource.FILE: _DEFAULT_SOURCE_IMAGE_FILENAME,

--- a/backend/tests/daily/connectors/jira_service_management/test_jsm_basic.py
+++ b/backend/tests/daily/connectors/jira_service_management/test_jsm_basic.py
@@ -1,0 +1,99 @@
+import time
+from unittest.mock import patch
+
+import pytest
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.jira_service_management.connector import (
+    JiraServiceManagementConnector,
+)
+from onyx.connectors.models import Document
+from tests.daily.connectors.utils import load_all_from_connector
+from tests.utils.secret_names import TestSecret
+
+# Credentials are the same as the Jira connector's; the base URL must point at
+# a Jira instance with a Jira Service Management project whose key is
+# JSM_PROJECT_KEY. For reference, danswerai.atlassian.net uses the "ITSM"
+# service desk project.
+JSM_BASE_URL = "https://danswerai.atlassian.net"
+JSM_PROJECT_KEY = "ITSM"
+
+pytestmark = pytest.mark.secrets(
+    TestSecret.JIRA_USER_EMAIL,
+    TestSecret.JIRA_API_TOKEN,
+)
+
+
+@pytest.fixture
+def jsm_connector(
+    test_secrets: dict[TestSecret, str],
+) -> JiraServiceManagementConnector:
+    connector = JiraServiceManagementConnector(
+        jira_base_url=JSM_BASE_URL,
+        project_key=JSM_PROJECT_KEY,
+        comment_email_blacklist=[],
+    )
+    connector.load_credentials(
+        {
+            "jira_user_email": test_secrets[TestSecret.JIRA_USER_EMAIL],
+            "jira_api_token": test_secrets[TestSecret.JIRA_API_TOKEN],
+        }
+    )
+    connector.validate_connector_settings()
+    return connector
+
+
+@patch(
+    "onyx.file_processing.extract_file_text.get_unstructured_api_key",
+    return_value=None,
+)
+def test_jsm_connector_basic(
+    reset: None,  # noqa: ARG001
+    jsm_connector: JiraServiceManagementConnector,
+) -> None:
+    docs = load_all_from_connector(
+        connector=jsm_connector,
+        start=0,
+        end=time.time(),
+    ).documents
+
+    assert len(docs) > 0, (
+        "No documents were retrieved from the Jira Service Management connector"
+    )
+
+    for doc in docs:
+        assert isinstance(doc, Document)
+        # Every ticket is branded as a Jira Service Management document
+        assert doc.source == DocumentSource.JIRA_SERVICE_MANAGEMENT
+        # Document IDs are the browse URLs of the tickets
+        assert doc.id.startswith(JSM_BASE_URL)
+        # Tickets are scoped to the configured service desk project
+        assert doc.metadata.get("project") == JSM_PROJECT_KEY
+        # JSM enrichment: every JSM ticket carries its request type
+        assert doc.metadata.get("customer_request_type")
+
+        assert len(doc.sections) == 1
+        assert doc.sections[0].link == doc.id
+
+
+@patch(
+    "onyx.file_processing.extract_file_text.get_unstructured_api_key",
+    return_value=None,
+)
+def test_jsm_connector_slim_docs(
+    reset: None,  # noqa: ARG001
+    jsm_connector: JiraServiceManagementConnector,
+) -> None:
+    from onyx.connectors.models import SlimDocument
+
+    slim_batches = list(jsm_connector.retrieve_all_slim_docs(start=0, end=time.time()))
+    slim_docs = [
+        slim_doc
+        for batch in slim_batches
+        for slim_doc in batch
+        if isinstance(slim_doc, SlimDocument)
+    ]
+
+    assert len(slim_docs) > 0, "No slim documents were retrieved"
+    for slim_doc in slim_docs:
+        assert slim_doc.id.startswith(JSM_BASE_URL)

--- a/backend/tests/unit/onyx/connectors/jira_service_management/conftest.py
+++ b/backend/tests/unit/onyx/connectors/jira_service_management/conftest.py
@@ -1,0 +1,184 @@
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from jira import JIRA
+from jira.resources import Issue
+
+from onyx.connectors.jira_service_management.connector import (
+    JiraServiceManagementConnector,
+)
+from onyx.connectors.jira_service_management.utils import JsmFieldMap
+
+TEST_BASE_URL = "https://support.example.com"
+TEST_PROJECT_KEY = "HELP"
+
+# Custom field IDs as they'd appear on a real (cloud) Jira instance; the
+# connector must discover these by name, never hard-code them.
+REQUEST_TYPE_FIELD_ID = "customfield_10010"
+ORGANIZATIONS_FIELD_ID = "customfield_10001"
+SLA_FIRST_RESPONSE_FIELD_ID = "customfield_10020"
+SLA_RESOLUTION_FIELD_ID = "customfield_10021"
+
+
+@pytest.fixture
+def jira_base_url() -> str:
+    return TEST_BASE_URL
+
+
+@pytest.fixture
+def project_key() -> str:
+    return TEST_PROJECT_KEY
+
+
+@pytest.fixture
+def jsm_field_map() -> JsmFieldMap:
+    return JsmFieldMap(
+        customer_request_type=REQUEST_TYPE_FIELD_ID,
+        organizations=ORGANIZATIONS_FIELD_ID,
+    )
+
+
+class MockUser:
+    def __init__(self, display_name: str, email: str | None = None) -> None:
+        self.displayName = display_name
+        if email:
+            self.emailAddress = email
+
+
+class MockComment:
+    def __init__(
+        self,
+        body: str,
+        author: MockUser | None = None,
+        is_public: bool = True,
+    ) -> None:
+        self.body = body
+        if author is not None:
+            self.author = author
+        self.raw = {"body": body, "jsdPublic": is_public}
+
+
+def make_mock_jsm_issue(
+    key: str = "HELP-101",
+    summary: str = "VPN not connecting",
+    description: str = "Unable to connect to the corporate VPN.",
+    project_key: str = TEST_PROJECT_KEY,
+    project_name: str = "IT Help Desk",
+    labels: list[str] | None = None,
+    comments: list[MockComment] | None = None,
+    request_type: str | None = "Get IT help",
+    organizations: list[str] | None = None,
+    slas: dict[str, Any] | None = None,
+    field_map: JsmFieldMap | None = None,
+    raw_overrides: dict[str, Any] | None = None,
+    created: str = "2026-09-01T10:00:00.000+0000",
+    updated: str = "2026-09-02T14:30:00.000+0000",
+) -> Issue:
+    """Build a mock Jira Issue carrying realistic JSM raw fields."""
+    issue = MagicMock(spec=Issue)
+    issue.key = key
+
+    fields = MagicMock()
+    fields.summary = summary
+    fields.description = description
+    fields.labels = labels or []
+    fields.created = created
+    fields.updated = updated
+
+    fields.reporter = MockUser("Alice Requester", "alice@example.com")
+    fields.assignee = MockUser("Bob Agent", "bob@example.com")
+
+    fields.priority = MagicMock()
+    fields.priority.name = "High"
+
+    fields.status = MagicMock()
+    fields.status.name = "Waiting for support"
+
+    fields.resolution = None
+    fields.duedate = None
+    fields.resolutiondate = None
+
+    fields.issuetype = MagicMock()
+    fields.issuetype.name = "Service Request"
+
+    project = MagicMock()
+    project.key = project_key
+    project.name = project_name
+    fields.project = project
+
+    fields.parent = None
+
+    if comments is None:
+        comments = [
+            MockComment(
+                body="Have you tried restarting your laptop?",
+                author=MockUser("Bob Agent", "bob@example.com"),
+                is_public=True,
+            ),
+            MockComment(
+                body="Checked the VPN gateway logs; cert expired.",
+                author=MockUser("Bob Agent", "bob@example.com"),
+                is_public=False,
+            ),
+        ]
+    comment_container = MagicMock()
+    comment_container.comments = comments
+    fields.comment = comment_container
+
+    issue.fields = fields
+
+    raw_fields: dict[str, Any] = {"description": description}
+    if field_map is None:
+        field_map = JsmFieldMap(
+            customer_request_type=REQUEST_TYPE_FIELD_ID,
+            organizations=ORGANIZATIONS_FIELD_ID,
+        )
+
+    if request_type is not None and field_map.customer_request_type:
+        raw_fields[field_map.customer_request_type] = request_type
+    if organizations is not None and field_map.organizations:
+        raw_fields[field_map.organizations] = [
+            {"id": str(i + 1), "name": org} for i, org in enumerate(organizations)
+        ]
+    if slas is not None:
+        raw_fields.update(slas)
+
+    if raw_overrides:
+        raw_fields.update(raw_overrides)
+
+    issue.raw = {"fields": raw_fields}
+    return issue
+
+
+@pytest.fixture
+def mock_jira_client() -> MagicMock:
+    mock = MagicMock(spec=JIRA)
+    mock.search_issues = MagicMock()
+    mock.project = MagicMock()
+    mock.projects = MagicMock()
+    mock.fields = MagicMock()
+    return mock
+
+
+@pytest.fixture
+def make_jsm_connector(
+    mock_jira_client: MagicMock,
+) -> Callable[..., JiraServiceManagementConnector]:
+    """Factory fixture producing a JSM connector backed by the mock client."""
+
+    def _make(
+        project_key: str = TEST_PROJECT_KEY,
+        **kwargs: Any,
+    ) -> JiraServiceManagementConnector:
+        connector = JiraServiceManagementConnector(
+            jira_base_url=TEST_BASE_URL,
+            project_key=project_key,
+            comment_email_blacklist=kwargs.pop("comment_email_blacklist", []),
+            **kwargs,
+        )
+        connector._jira_client = mock_jira_client
+        return connector
+
+    return _make

--- a/backend/tests/unit/onyx/connectors/jira_service_management/test_jira_service_management_connector.py
+++ b/backend/tests/unit/onyx/connectors/jira_service_management/test_jira_service_management_connector.py
@@ -1,0 +1,554 @@
+import time
+from collections.abc import Callable, Generator
+from typing import cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+from jira import JIRA, JIRAError
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.connector_runner import CheckpointOutputWrapper
+from onyx.connectors.exceptions import (
+    ConnectorValidationError,
+    CredentialExpiredError,
+    InsufficientPermissionsError,
+    UnexpectedValidationError,
+)
+from onyx.connectors.interfaces import (
+    CheckpointedConnectorWithPermSync,
+    SlimConnector,
+    SlimConnectorWithPermSync,
+)
+from onyx.connectors.jira.connector import JiraConnector, JiraConnectorCheckpoint
+from onyx.connectors.jira_service_management.connector import (
+    JiraServiceManagementConnector,
+)
+from onyx.connectors.jira_service_management.utils import (
+    FIELD_CUSTOMER_REQUEST_TYPE,
+    FIELD_ORGANIZATIONS,
+    FIELD_SLA_STATUS,
+    JsmFieldMap,
+)
+from onyx.connectors.models import (
+    ConnectorFailure,
+    ConnectorMissingCredentialError,
+    Document,
+    HierarchyNode,
+    SlimDocument,
+    TextSection,
+)
+from tests.unit.onyx.connectors.jira_service_management.conftest import (
+    ORGANIZATIONS_FIELD_ID,
+    REQUEST_TYPE_FIELD_ID,
+    SLA_FIRST_RESPONSE_FIELD_ID,
+    SLA_RESOLUTION_FIELD_ID,
+    TEST_BASE_URL,
+    TEST_PROJECT_KEY,
+    make_mock_jsm_issue,
+)
+from tests.unit.onyx.connectors.utils import (
+    load_everything_from_checkpoint_connector,
+)
+
+PAGE_SIZE = 2
+
+
+@pytest.fixture
+def jsm_connector(
+    make_jsm_connector: Callable[..., JiraServiceManagementConnector],
+    jsm_field_map: JsmFieldMap,
+) -> Generator[JiraServiceManagementConnector, None, None]:
+    """Connector with JSM field discovery short-circuited for determinism."""
+    connector = make_jsm_connector()
+    connector._jsm_field_map = jsm_field_map
+    jira_client = cast(JIRA, connector._jira_client)
+    jira_client._options = MagicMock()
+    with patch("onyx.connectors.jira.connector._JIRA_FULL_PAGE_SIZE", 2):
+        yield connector
+
+
+class TestProcessIssue:
+    def test_process_issue_full_jsm_metadata(
+        self, jsm_connector: JiraServiceManagementConnector
+    ) -> None:
+        issue = make_mock_jsm_issue(
+            organizations=["Acme Corp", "Beta LLC"],
+            slas={
+                SLA_FIRST_RESPONSE_FIELD_ID: {
+                    "name": "Time to first response",
+                    "completedCycles": [{"breached": False}],
+                },
+                SLA_RESOLUTION_FIELD_ID: {
+                    "name": "Time to resolution",
+                    "ongoingCycle": {"breached": False},
+                },
+            },
+        )
+
+        document = jsm_connector._process_issue(issue)
+        assert document is not None
+
+        assert document.id == f"{TEST_BASE_URL}/browse/HELP-101"
+        assert document.source == DocumentSource.JIRA_SERVICE_MANAGEMENT
+        assert document.semantic_identifier == "HELP-101: VPN not connecting"
+        assert document.title == "HELP-101 VPN not connecting"
+
+        # Standard Jira metadata is preserved
+        assert document.metadata["key"] == "HELP-101"
+        assert document.metadata["status"] == "Waiting for support"
+        assert document.metadata["priority"] == "High"
+        assert document.metadata["project"] == TEST_PROJECT_KEY
+        assert document.metadata["project_name"] == "IT Help Desk"
+
+        # JSM specific metadata
+        assert document.metadata[FIELD_CUSTOMER_REQUEST_TYPE] == "Get IT help"
+        assert document.metadata[FIELD_ORGANIZATIONS] == ["Acme Corp", "Beta LLC"]
+        assert document.metadata[FIELD_SLA_STATUS] == [
+            "Time to first response: Met",
+            "Time to resolution: In Progress",
+        ]
+
+        # Content: description plus public comment; internal note excluded by default
+        assert len(document.sections) == 1
+        section = document.sections[0]
+        assert isinstance(section, TextSection)
+        text = section.text
+        assert "Unable to connect to the corporate VPN." in text
+        assert "Have you tried restarting your laptop?" in text
+        assert "Checked the VPN gateway logs; cert expired." not in text
+
+    def test_process_issue_includes_internal_comments_when_enabled(
+        self, make_jsm_connector: Callable[..., JiraServiceManagementConnector]
+    ) -> None:
+        connector = make_jsm_connector(include_internal_comments=True)
+        connector._jsm_field_map = JsmFieldMap()
+        issue = make_mock_jsm_issue()
+
+        document = connector._process_issue(issue)
+        assert document is not None
+        section = document.sections[0]
+        assert isinstance(section, TextSection)
+        text = section.text
+        assert "Have you tried restarting your laptop?" in text
+        assert "[Internal Note] Checked the VPN gateway logs; cert expired." in text
+
+    def test_process_issue_comment_email_blacklist(
+        self, make_jsm_connector: Callable[..., JiraServiceManagementConnector]
+    ) -> None:
+        connector = make_jsm_connector(
+            comment_email_blacklist=["bob@example.com"],
+            include_internal_comments=True,
+        )
+        connector._jsm_field_map = JsmFieldMap()
+        issue = make_mock_jsm_issue()
+
+        document = connector._process_issue(issue)
+        assert document is not None
+        section = document.sections[0]
+        assert isinstance(section, TextSection)
+        text = section.text
+        # All comments are authored by bob@example.com
+        assert "Have you tried restarting your laptop?" not in text
+        assert "Checked the VPN gateway logs; cert expired." not in text
+
+    def test_process_issue_skips_labeled_tickets(
+        self, jsm_connector: JiraServiceManagementConnector
+    ) -> None:
+        jsm_connector.labels_to_skip = {"sensitive"}
+        issue = make_mock_jsm_issue(labels=["vpn", "sensitive"])
+        assert jsm_connector._process_issue(issue) is None
+
+    def test_process_issue_skips_oversized_tickets(
+        self, jsm_connector: JiraServiceManagementConnector
+    ) -> None:
+        issue = make_mock_jsm_issue(description="way too big " * 10)
+        with patch("onyx.connectors.jira.connector.JIRA_CONNECTOR_MAX_TICKET_SIZE", 10):
+            assert jsm_connector._process_issue(issue) is None
+
+    def test_process_issue_structural_fallback_without_field_map(
+        self, make_jsm_connector: Callable[..., JiraServiceManagementConnector]
+    ) -> None:
+        """When field discovery fails, structure-based detection still works."""
+        connector = make_jsm_connector()
+        connector._jsm_field_map = JsmFieldMap()  # discovery produced nothing
+
+        issue = make_mock_jsm_issue(
+            request_type=None,
+            organizations=None,
+            field_map=JsmFieldMap(),
+            raw_overrides={
+                # request type embedded in an object (no known field ID)
+                "customfield_99999": {
+                    "requestType": {"name": "Report a security issue"}
+                },
+                # organizations shaped as {"id", "name"} pairs (no known field ID)
+                "customfield_88888": [
+                    {"id": "1", "name": "Globex"},
+                ],
+                SLA_FIRST_RESPONSE_FIELD_ID: {
+                    "name": "Time to first response",
+                    "ongoingCycle": {"breached": True},
+                },
+            },
+        )
+
+        document = connector._process_issue(issue)
+        assert document is not None
+        assert document.metadata[FIELD_CUSTOMER_REQUEST_TYPE] == (
+            "Report a security issue"
+        )
+        assert document.metadata[FIELD_ORGANIZATIONS] == ["Globex"]
+        assert document.metadata[FIELD_SLA_STATUS] == [
+            "Time to first response: Breached"
+        ]
+
+    def test_process_issue_structural_fallback_ignores_non_org_lists(
+        self, make_jsm_connector: Callable[..., JiraServiceManagementConnector]
+    ) -> None:
+        """Lists of dicts with extra keys (e.g. components) are not organizations."""
+        connector = make_jsm_connector()
+        connector._jsm_field_map = JsmFieldMap()
+
+        issue = make_mock_jsm_issue(
+            request_type=None,
+            organizations=None,
+            field_map=JsmFieldMap(),
+            raw_overrides={
+                "components": [{"id": "1", "name": "Backend", "description": "API"}],
+            },
+        )
+
+        document = connector._process_issue(issue)
+        assert document is not None
+        assert FIELD_ORGANIZATIONS not in document.metadata
+
+    def test_process_issue_hierarchy_parent_passthrough(
+        self, jsm_connector: JiraServiceManagementConnector
+    ) -> None:
+        issue = make_mock_jsm_issue()
+        document = jsm_connector._process_issue(issue, "HELP")
+        assert document is not None
+        assert document.parent_hierarchy_raw_node_id == "HELP"
+
+    def test_process_issue_completed_sla_breached(
+        self, jsm_connector: JiraServiceManagementConnector
+    ) -> None:
+        issue = make_mock_jsm_issue(
+            request_type=None,
+            organizations=None,
+            slas={
+                SLA_RESOLUTION_FIELD_ID: {
+                    "name": "Time to resolution",
+                    "completedCycles": [{"breached": True}],
+                },
+            },
+        )
+        document = jsm_connector._process_issue(issue)
+        assert document is not None
+        assert document.metadata[FIELD_SLA_STATUS] == ["Time to resolution: Breached"]
+
+
+class TestFieldDiscovery:
+    def test_discover_jsm_fields_by_name(self, mock_jira_client: MagicMock) -> None:
+        mock_jira_client.fields.return_value = [
+            {"id": "summary", "name": "Summary", "custom": False},
+            {"id": REQUEST_TYPE_FIELD_ID, "name": "Customer Request Type"},
+            {"id": ORGANIZATIONS_FIELD_ID, "name": "Organizations"},
+            {"id": "customfield_10002", "name": "Satisfaction"},
+        ]
+
+        connector = JiraServiceManagementConnector(
+            jira_base_url=TEST_BASE_URL, project_key=TEST_PROJECT_KEY
+        )
+        connector._jira_client = mock_jira_client
+
+        field_map = connector.jsm_field_map
+        assert field_map.customer_request_type == REQUEST_TYPE_FIELD_ID
+        assert field_map.organizations == ORGANIZATIONS_FIELD_ID
+
+        # cached: fields() is only fetched once
+        assert connector.jsm_field_map == field_map
+        assert mock_jira_client.fields.call_count == 1
+
+    def test_discover_jsm_fields_api_failure_falls_back(
+        self, mock_jira_client: MagicMock
+    ) -> None:
+        mock_jira_client.fields.side_effect = RuntimeError("403")
+
+        connector = JiraServiceManagementConnector(
+            jira_base_url=TEST_BASE_URL, project_key=TEST_PROJECT_KEY
+        )
+        connector._jira_client = mock_jira_client
+
+        field_map = connector.jsm_field_map
+        assert field_map.customer_request_type is None
+        assert field_map.organizations is None
+
+
+class TestCheckpointing:
+    def test_load_from_checkpoint_happy_path(
+        self, jsm_connector: JiraServiceManagementConnector
+    ) -> None:
+        mock_issue1 = make_mock_jsm_issue(key="HELP-1", summary="Issue 1")
+        mock_issue2 = make_mock_jsm_issue(key="HELP-2", summary="Issue 2")
+        mock_issue3 = make_mock_jsm_issue(key="HELP-3", summary="Issue 3")
+
+        jira_client = cast(JIRA, jsm_connector._jira_client)
+        search_issues_mock = cast(MagicMock, jira_client.search_issues)
+        search_issues_mock.side_effect = [
+            [mock_issue1, mock_issue2],
+            [mock_issue3],
+        ]
+
+        end_time = time.time()
+        outputs = load_everything_from_checkpoint_connector(jsm_connector, 0, end_time)
+
+        assert len(outputs) == 2
+
+        checkpoint_output1 = outputs[0]
+        assert len(checkpoint_output1.items) == 2
+        document1 = checkpoint_output1.items[0]
+        assert isinstance(document1, Document)
+        assert document1.id == f"{TEST_BASE_URL}/browse/HELP-1"
+        assert document1.source == DocumentSource.JIRA_SERVICE_MANAGEMENT
+        document2 = checkpoint_output1.items[1]
+        assert isinstance(document2, Document)
+        assert document2.id == f"{TEST_BASE_URL}/browse/HELP-2"
+        assert checkpoint_output1.next_checkpoint == JiraConnectorCheckpoint(
+            offset=2,
+            has_more=True,
+            seen_hierarchy_node_ids=[TEST_PROJECT_KEY],
+        )
+
+        checkpoint_output2 = outputs[1]
+        assert len(checkpoint_output2.items) == 1
+        document3 = checkpoint_output2.items[0]
+        assert isinstance(document3, Document)
+        assert document3.id == f"{TEST_BASE_URL}/browse/HELP-3"
+        assert checkpoint_output2.next_checkpoint == JiraConnectorCheckpoint(
+            offset=3,
+            has_more=False,
+            seen_hierarchy_node_ids=[TEST_PROJECT_KEY],
+        )
+
+        assert search_issues_mock.call_count == 2
+        args, kwargs = search_issues_mock.call_args_list[0]
+        assert kwargs["startAt"] == 0
+        assert kwargs["maxResults"] == PAGE_SIZE
+
+        args, kwargs = search_issues_mock.call_args_list[1]
+        assert kwargs["startAt"] == 2
+        assert kwargs["maxResults"] == PAGE_SIZE
+
+    def test_load_from_checkpoint_yields_hierarchy_node(
+        self, jsm_connector: JiraServiceManagementConnector
+    ) -> None:
+        mock_issue = make_mock_jsm_issue(key="HELP-1")
+
+        jira_client = cast(JIRA, jsm_connector._jira_client)
+        search_issues_mock = cast(MagicMock, jira_client.search_issues)
+        search_issues_mock.side_effect = [[mock_issue]]
+
+        end_time = time.time()
+        checkpoint = jsm_connector.build_dummy_checkpoint()
+        doc_batch_generator = CheckpointOutputWrapper[JiraConnectorCheckpoint]()(
+            jsm_connector.load_from_checkpoint(0, end_time, checkpoint)
+        )
+        nodes: list[HierarchyNode] = []
+        for document, hierarchy_node, failure, _ in doc_batch_generator:
+            if hierarchy_node is not None:
+                nodes.append(hierarchy_node)
+            if document is not None:
+                assert document.source == DocumentSource.JIRA_SERVICE_MANAGEMENT
+            assert failure is None
+
+        assert len(nodes) == 1
+        assert nodes[0].raw_node_id == TEST_PROJECT_KEY
+        assert nodes[0].display_name == "IT Help Desk"
+
+    def test_load_from_checkpoint_yields_failure_for_bad_issue(
+        self, jsm_connector: JiraServiceManagementConnector
+    ) -> None:
+        good_issue = make_mock_jsm_issue(key="HELP-1")
+        bad_issue = make_mock_jsm_issue(key="HELP-2", updated="not-a-timestamp")
+
+        jira_client = cast(JIRA, jsm_connector._jira_client)
+        search_issues_mock = cast(MagicMock, jira_client.search_issues)
+        search_issues_mock.side_effect = [[good_issue, bad_issue], []]
+
+        end_time = time.time()
+        outputs = load_everything_from_checkpoint_connector(jsm_connector, 0, end_time)
+
+        # The good ticket is still indexed, the bad one surfaces as a failure
+        documents = [item for item in outputs[0].items if isinstance(item, Document)]
+        failures = [
+            item for item in outputs[0].items if isinstance(item, ConnectorFailure)
+        ]
+        assert len(documents) == 1
+        assert documents[0].id == f"{TEST_BASE_URL}/browse/HELP-1"
+        assert len(failures) == 1
+        assert failures[0].failed_document is not None
+        assert failures[0].failed_document.document_id == "HELP-2"
+
+    def test_retrieve_all_slim_docs(
+        self, jsm_connector: JiraServiceManagementConnector
+    ) -> None:
+        mock_issue1 = make_mock_jsm_issue(key="HELP-1")
+        mock_issue2 = make_mock_jsm_issue(key="HELP-2")
+
+        jira_client = cast(JIRA, jsm_connector._jira_client)
+        search_issues_mock = cast(MagicMock, jira_client.search_issues)
+        search_issues_mock.return_value = [mock_issue1, mock_issue2]
+
+        batches = list(jsm_connector.retrieve_all_slim_docs(0, 100))
+
+        assert len(batches) == 1
+        slim_docs = [item for item in batches[0] if isinstance(item, SlimDocument)]
+        assert [slim_doc.id for slim_doc in slim_docs] == [
+            f"{TEST_BASE_URL}/browse/HELP-1",
+            f"{TEST_BASE_URL}/browse/HELP-2",
+        ]
+
+
+class TestValidateConnectorSettings:
+    def test_missing_credentials(self) -> None:
+        connector = JiraServiceManagementConnector(
+            jira_base_url=TEST_BASE_URL, project_key=TEST_PROJECT_KEY
+        )
+        with pytest.raises(ConnectorMissingCredentialError):
+            connector.validate_connector_settings()
+
+    def test_missing_project_key(self, mock_jira_client: MagicMock) -> None:
+        connector = JiraServiceManagementConnector(
+            jira_base_url=TEST_BASE_URL, project_key=""
+        )
+        connector._jira_client = mock_jira_client
+        with pytest.raises(ConnectorValidationError, match="project key is required"):
+            connector.validate_connector_settings()
+
+    def test_rejects_non_service_desk_project(
+        self, make_jsm_connector: Callable[..., JiraServiceManagementConnector]
+    ) -> None:
+        connector = make_jsm_connector()
+        software_project = MagicMock()
+        software_project.projectTypeKey = "software"
+        jira_client = cast(JIRA, connector._jira_client)
+        project_mock = cast(MagicMock, jira_client.project)
+        project_mock.return_value = software_project
+
+        with pytest.raises(ConnectorValidationError, match="service desk"):
+            connector.validate_connector_settings()
+
+    def test_accepts_service_desk_project(
+        self, make_jsm_connector: Callable[..., JiraServiceManagementConnector]
+    ) -> None:
+        connector = make_jsm_connector()
+        service_desk_project = MagicMock()
+        service_desk_project.projectTypeKey = "service_desk"
+        jira_client = cast(JIRA, connector._jira_client)
+        project_mock = cast(MagicMock, jira_client.project)
+        project_mock.return_value = service_desk_project
+
+        connector.validate_connector_settings()
+        project_mock.assert_called_once_with(TEST_PROJECT_KEY)
+
+    def test_accepts_service_desk_project_via_raw(
+        self, make_jsm_connector: Callable[..., JiraServiceManagementConnector]
+    ) -> None:
+        connector = make_jsm_connector()
+        # projectTypeKey only available on the raw payload (e.g. server instances)
+        project = MagicMock()
+        project.raw = {"projectTypeKey": "service_desk"}
+        jira_client = cast(JIRA, connector._jira_client)
+        project_mock = cast(MagicMock, jira_client.project)
+        project_mock.return_value = project
+
+        connector.validate_connector_settings()
+
+    @pytest.mark.parametrize(
+        "status_code,expected_exception,expected_message",
+        [
+            (401, CredentialExpiredError, "expired or invalid"),
+            (403, InsufficientPermissionsError, "sufficient permissions"),
+            (404, UnexpectedValidationError, "Unexpected Jira error"),
+            (429, ConnectorValidationError, "rate-limits"),
+        ],
+    )
+    def test_project_lookup_error_mapping(
+        self,
+        make_jsm_connector: Callable[..., JiraServiceManagementConnector],
+        status_code: int,
+        expected_exception: type[Exception],
+        expected_message: str,
+    ) -> None:
+        connector = make_jsm_connector()
+        jira_client = cast(JIRA, connector._jira_client)
+        project_mock = cast(MagicMock, jira_client.project)
+        project_mock.side_effect = JIRAError(status_code=status_code)
+
+        with pytest.raises(expected_exception) as excinfo:
+            connector.validate_connector_settings()
+        assert expected_message in str(excinfo.value)
+
+    def test_jql_query_validation_failure(self, mock_jira_client: MagicMock) -> None:
+        connector = JiraServiceManagementConnector(
+            jira_base_url=TEST_BASE_URL,
+            project_key=TEST_PROJECT_KEY,
+            jql_query="issuetype = Incident",
+        )
+        connector._jira_client = mock_jira_client
+
+        service_desk_project = MagicMock()
+        service_desk_project.projectTypeKey = "service_desk"
+        mock_jira_client.project.return_value = service_desk_project
+
+        with patch(
+            "onyx.connectors.jira_service_management.connector._perform_jql_search",
+            side_effect=JIRAError(status_code=400, text="Bad JQL"),
+        ):
+            with pytest.raises(ConnectorValidationError, match="Bad JQL"):
+                connector.validate_connector_settings()
+
+    def test_jql_query_validation_success(self, mock_jira_client: MagicMock) -> None:
+        connector = JiraServiceManagementConnector(
+            jira_base_url=TEST_BASE_URL,
+            project_key=TEST_PROJECT_KEY,
+            jql_query="issuetype = Incident",
+        )
+        connector._jira_client = mock_jira_client
+
+        service_desk_project = MagicMock()
+        service_desk_project.projectTypeKey = "service_desk"
+        mock_jira_client.project.return_value = service_desk_project
+
+        with patch(
+            "onyx.connectors.jira_service_management.connector._perform_jql_search",
+            return_value=iter([]),
+        ):
+            connector.validate_connector_settings()
+
+
+class TestInheritanceContract:
+    def test_document_source_override(self) -> None:
+        assert JiraConnector.document_source == DocumentSource.JIRA
+        assert (
+            JiraServiceManagementConnector.document_source
+            == DocumentSource.JIRA_SERVICE_MANAGEMENT
+        )
+
+    def test_is_a_checkpointed_connector_with_perm_sync_and_slim(
+        self, make_jsm_connector: Callable[..., JiraServiceManagementConnector]
+    ) -> None:
+        connector = make_jsm_connector()
+        assert isinstance(connector, CheckpointedConnectorWithPermSync)
+        assert isinstance(connector, SlimConnector)
+        assert isinstance(connector, SlimConnectorWithPermSync)
+
+        checkpoint = connector.build_dummy_checkpoint()
+        assert isinstance(checkpoint, JiraConnectorCheckpoint)
+        assert checkpoint.has_more is True
+
+        assert (
+            connector.validate_checkpoint_json(checkpoint.model_dump_json())
+            == checkpoint
+        )

--- a/backend/tests/unit/onyx/connectors/jira_service_management/test_jsm_utils.py
+++ b/backend/tests/unit/onyx/connectors/jira_service_management/test_jsm_utils.py
@@ -1,0 +1,158 @@
+from unittest.mock import MagicMock
+
+from jira import JIRA
+from jira.resources import Issue
+
+from onyx.connectors.jira_service_management.utils import (
+    CUSTOMER_REQUEST_TYPE_FIELD_NAME,
+    ORGANIZATIONS_FIELD_NAME,
+    discover_jsm_fields,
+    extract_customer_request_type,
+    extract_organizations,
+    extract_sla_info,
+    get_jsm_comment_strs,
+)
+from tests.unit.onyx.connectors.jira_service_management.conftest import (
+    MockComment,
+    MockUser,
+    make_mock_jsm_issue,
+)
+
+
+class TestDiscoverJsmFields:
+    def test_discovers_fields_by_display_name(self) -> None:
+        client = MagicMock(spec=JIRA)
+        client.fields.return_value = [
+            {"id": "customfield_10003", "name": "Team"},
+            {
+                "id": "customfield_10010",
+                "name": CUSTOMER_REQUEST_TYPE_FIELD_NAME,
+            },
+            {"id": "customfield_10001", "name": ORGANIZATIONS_FIELD_NAME},
+        ]
+
+        field_map = discover_jsm_fields(client)
+        assert field_map.customer_request_type == "customfield_10010"
+        assert field_map.organizations == "customfield_10001"
+
+    def test_returns_empty_map_when_fields_unavailable(self) -> None:
+        client = MagicMock(spec=JIRA)
+        client.fields.side_effect = RuntimeError("not permitted")
+
+        field_map = discover_jsm_fields(client)
+        assert field_map.customer_request_type is None
+        assert field_map.organizations is None
+
+
+class TestExtractCustomerRequestType:
+    def test_by_field_id_string_value(self) -> None:
+        # Cloud returns "<serviceDeskId>/<requestTypeId>" strings
+        issue = make_mock_jsm_issue(request_type="helpdesk/12")
+        assert (
+            extract_customer_request_type(issue, "customfield_10010") == "helpdesk/12"
+        )
+
+    def test_by_field_id_object_value(self) -> None:
+        issue = make_mock_jsm_issue(
+            request_type=None,
+            raw_overrides={
+                "customfield_10010": {"requestType": {"name": "Get IT help"}}
+            },
+        )
+        assert (
+            extract_customer_request_type(issue, "customfield_10010") == "Get IT help"
+        )
+
+    def test_structural_fallback_without_field_id(self) -> None:
+        issue = make_mock_jsm_issue(
+            request_type=None,
+            raw_overrides={
+                "customfield_12345": {"name": "Wifi access", "serviceDeskId": "7"}
+            },
+        )
+        assert extract_customer_request_type(issue) == "Wifi access"
+
+    def test_missing_everywhere_returns_none(self) -> None:
+        issue = make_mock_jsm_issue(request_type=None)
+        assert extract_customer_request_type(issue, "customfield_10010") is None
+
+
+class TestExtractOrganizations:
+    def test_by_field_id(self) -> None:
+        issue = make_mock_jsm_issue(organizations=["Acme", "Beta LLC"])
+        assert extract_organizations(issue, "customfield_10001") == [
+            "Acme",
+            "Beta LLC",
+        ]
+
+    def test_structural_fallback(self) -> None:
+        issue = make_mock_jsm_issue(
+            organizations=None,
+            raw_overrides={"customfield_55555": [{"id": "3", "name": "Initech"}]},
+        )
+        assert extract_organizations(issue) == ["Initech"]
+
+    def test_no_organizations_returns_empty_list(self) -> None:
+        issue = make_mock_jsm_issue(organizations=[])
+        assert extract_organizations(issue, "customfield_10001") == []
+
+
+class TestExtractSlaInfo:
+    def test_ongoing_and_completed_cycles(self) -> None:
+        issue = make_mock_jsm_issue(
+            slas={
+                "customfield_10020": {
+                    "name": "Time to first response",
+                    "ongoingCycle": {"breached": False},
+                },
+                "customfield_10021": {
+                    "name": "Time to resolution",
+                    "completedCycles": [{"breached": True}],
+                },
+            }
+        )
+        assert extract_sla_info(issue) == {
+            "Time to first response": "In Progress",
+            "Time to resolution": "Breached",
+        }
+
+    def test_no_sla_fields_returns_empty_dict(self) -> None:
+        issue = make_mock_jsm_issue()
+        assert extract_sla_info(issue) == {}
+
+
+class TestGetJsmCommentStrs:
+    def test_public_comments_only_by_default(self) -> None:
+        issue = make_mock_jsm_issue()
+        comments = get_jsm_comment_strs(issue)
+        assert comments == ["Have you tried restarting your laptop?"]
+
+    def test_internal_comments_included_and_tagged(self) -> None:
+        issue = make_mock_jsm_issue()
+        comments = get_jsm_comment_strs(issue, include_internal_comments=True)
+        assert comments == [
+            "Have you tried restarting your laptop?",
+            "[Internal Note] Checked the VPN gateway logs; cert expired.",
+        ]
+
+    def test_blacklisted_author_skipped(self) -> None:
+        issue = make_mock_jsm_issue(
+            comments=[
+                MockComment(
+                    body="from bob",
+                    author=MockUser("Bob Agent", "bob@example.com"),
+                ),
+                MockComment(
+                    body="from alice",
+                    author=MockUser("Alice", "alice@example.com"),
+                ),
+            ]
+        )
+        comments = get_jsm_comment_strs(
+            issue, comment_email_blacklist=("bob@example.com",)
+        )
+        assert comments == ["from alice"]
+
+    def test_no_comments_attribute(self) -> None:
+        issue = MagicMock(spec=Issue)  # spec'd mock: no fields materialized
+        assert get_jsm_comment_strs(issue) == []

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -862,6 +862,69 @@ export const connectorConfigs: Record<
     ],
     advanced_values: [],
   },
+  jira_service_management: {
+    description: "Configure Jira Service Management connector",
+    subtext: `Configure which Jira Service Management project to index. All tickets (customer requests) in the specified service desk project will be ingested.`,
+    values: [
+      {
+        type: "text",
+        query: "Enter the Jira base URL:",
+        label: "Jira Base URL",
+        name: "jira_base_url",
+        optional: false,
+        description:
+          "The base URL of your Jira instance (e.g., https://your-domain.atlassian.net)",
+      },
+      {
+        type: "text",
+        query: "Enter the Service Management project key:",
+        label: "Project Key",
+        name: "project_key",
+        optional: false,
+        description:
+          "The project key of the Jira Service Management project to index (e.g., 'HELP').",
+      },
+      {
+        type: "checkbox",
+        query: "Using scoped token?",
+        label: "Using scoped token",
+        name: "scoped_token",
+        optional: true,
+        default: false,
+      },
+      {
+        type: "checkbox",
+        query: "Include internal agent notes?",
+        label: "Include internal notes",
+        name: "include_internal_comments",
+        optional: true,
+        default: false,
+        description:
+          "Jira Service Management comments can be public (visible to customers) or internal agent notes. Enable this to also index internal notes; they will be tagged with '[Internal Note]'.",
+      },
+      {
+        type: "list",
+        query: "Enter email addresses to blacklist from comments:",
+        label: "Comment Email Blacklist",
+        name: "comment_email_blacklist",
+        description:
+          "This is generally useful to ignore certain bots. Add user emails which comments should NOT be indexed.",
+        optional: true,
+      },
+    ],
+    advanced_values: [
+      {
+        type: "text",
+        query: "Enter an additional JQL filter (optional):",
+        label: "Custom JQL Query",
+        name: "jql_query",
+        optional: true,
+        description:
+          "Optional JQL to further filter which tickets are indexed (e.g., 'issuetype in (Incident, Service Request)')." +
+          "\n\nIMPORTANT: Do not include any time-based filters or project clauses in the JQL query as that will conflict with the connector's logic.",
+      },
+    ],
+  },
   salesforce: {
     description: "Configure Salesforce connector",
     values: [
@@ -2192,6 +2255,15 @@ export interface JiraConfig {
   project_key?: string;
   comment_email_blacklist?: string[];
   jql_query?: string;
+}
+
+export interface JiraServiceManagementConfig {
+  jira_base_url: string;
+  project_key: string;
+  scoped_token?: boolean;
+  comment_email_blacklist?: string[];
+  jql_query?: string;
+  include_internal_comments?: boolean;
 }
 
 export interface SalesforceConfig {

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -329,6 +329,7 @@ type CredentialTemplateMap = Record<ValidSources, object | null> & {
   outline: OutlineCredentialJson;
   confluence: ConfluenceCredentialJson;
   jira: JiraCredentialJson;
+  jira_service_management: JiraCredentialJson;
   productboard: ProductboardCredentialJson;
   slab: SlabCredentialJson;
   coda: CodaCredentialJson;
@@ -403,6 +404,10 @@ export const credentialTemplates: Record<ValidSources, any> = {
     confluence_access_token: "",
   },
   jira: {
+    jira_user_email: null,
+    jira_api_token: "",
+  },
+  jira_service_management: {
     jira_user_email: null,
     jira_api_token: "",
   },

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -264,6 +264,12 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     docs: `${DOCS_ADMINS_PATH}/connectors/official/jira`,
     isPopular: true,
   },
+  jira_service_management: {
+    icon: SvgJira,
+    displayName: "Jira Service Management",
+    category: SourceCategory.TicketingAndTaskManagement,
+    docs: `${DOCS_ADMINS_PATH}/connectors/official/jira_service_management`,
+  },
   zendesk: {
     icon: SvgZendesk,
     displayName: "Zendesk",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -609,6 +609,7 @@ export enum ValidSources {
   Outline = "outline",
   Confluence = "confluence",
   Jira = "jira",
+  JiraServiceManagement = "jira_service_management",
   Productboard = "productboard",
   Slab = "slab",
   Coda = "coda",


### PR DESCRIPTION
## Description

Resolves #2281 — adds a dedicated **Jira Service Management (JSM) connector** that pulls in all tickets (customer requests) from a specified JSM project, following the [connector creation README](https://github.com/onyx-dot-app/onyx/blob/main/backend/onyx/connectors/README.md) checklist.

JSM is backed by the same Jira REST API as regular Jira, so the connector subclasses the existing `JiraConnector` and inherits its battle-tested machinery: checkpointed pagination (v3 enhanced JQL search + bulk fetch for Cloud, v2 offset search for Server/DC), slim-doc retrieval for pruning, project/epic hierarchy, and permission sync. On top of that it specializes:

- **Source branding** — documents are stamped `DocumentSource.JIRA_SERVICE_MANAGEMENT`. `JiraConnector` gained a `document_source: ClassVar[DocumentSource]` and a small overridable `_process_issue` hook (plus an optional `comment_extractor` parameter on `process_jira_issue`), so no logic had to be duplicated in the subclass and behavior of the existing Jira connector is unchanged.
- **JSM-aware comments** — JSM comments carry a `jsdPublic` flag; internal agent notes (`jsdPublic == False`) are **excluded by default** and can be included via `include_internal_comments` (tagged with an `[Internal Note]` prefix so retrieval can distinguish them). Public comments are always indexed.
- **JSM metadata without hard-coded field IDs** — customer request type, organizations, and SLA statuses live in custom fields whose IDs (`customfield_XXXXX`) differ per instance. The connector discovers them **by their stable display names** ("Customer Request Type", "Organizations") via the fields endpoint at first use (cached), and falls back to structural value detection (e.g. SLA values always carry `ongoingCycle`/`completedCycles`; organizations are lists of `{id, name}` pairs; request-type objects carry a nested `requestType.name`) when discovery is unavailable. This avoids the brittle hard-coded IDs most JSM integrations rely on.
- **Validation** — `validate_connector_settings` requires a project key (the general-purpose Jira connector is the right tool for indexing everything) and verifies the project actually is a service desk project (`projectTypeKey == 'service_desk'`, checked best-effort when the instance exposes it), surfacing clear errors for wrong project type / expired credentials (401) / insufficient permissions (403) / rate limits (429).
- **Incremental sync** — inherited time-windowed JQL (`updated >= <epoch-ms>`) with checkpointing, so only changed tickets are re-indexed between full passes.

### Checklist from the connector README

- [x] Connector subclasses `CheckpointedConnectorWithPermSync`, `SlimConnector`, `SlimConnectorWithPermSync` (via `JiraConnector`); `__init__` takes the JSM base URL, project key, comment email blacklist, label skip list, optional JQL filter, scoped-token flag and internal-comments flag
- [x] `load_credentials` accepts the Jira user email + API token (same credential type as the Jira connector)
- [x] `DocumentSource.JIRA_SERVICE_MANAGEMENT` added to `backend/onyx/configs/constants.py` (+ description map)
- [x] Connector mapping added to `backend/onyx/connectors/registry.py`
- [x] Slack bot source icon mapping added to `backend/onyx/onyxbot/slack/icons.py`
- [x] Frontend: `ValidSources` enum (`web/src/lib/types.ts`), `SOURCE_METADATA_MAP` (`web/src/lib/sources.ts`), `connectorConfigs` + `JiraServiceManagementConfig` (`web/src/lib/connectors/connectors.tsx`), credential template (`web/src/lib/connectors/credentials.ts`)
- [x] Unit tests under `backend/tests/unit/onyx/connectors/jira_service_management/`; daily connector test under `backend/tests/daily/connectors/jira_service_management/`
- [x] `ruff check` / `ruff format` clean; `ty check` (pinned `0.0.63`) clean on all new and modified backend files

Docs page for the new connector will be contributed to the [documentation repo](https://github.com/onyx-dot-app/documentation).

## How Has This Been Tested?

**Unit tests (43 new, all passing locally with mocked API responses):**

- `backend/tests/unit/onyx/connectors/jira_service_management/test_jira_service_management_connector.py`
  - Document processing: full JSM metadata (request type, organizations, SLA statuses), standard Jira metadata preservation, source branding, internal notes excluded by default / included-and-tagged when opted in, comment email blacklist, label-based skipping, oversized-ticket skipping, structural fallback when field discovery fails, and non-organization lists (e.g. components) correctly not treated as organizations
  - Field discovery: by display name, caching (single `fields()` call), graceful fallback when the endpoint fails
  - Checkpointing: paginated `load_from_checkpoint` (offsets, `has_more`, resume), hierarchy node emission, per-issue failures surfaced as `ConnectorFailure` without losing the rest of the batch, slim-doc retrieval
  - Validation: missing credentials, missing project key, non-service-desk project rejection, service-desk acceptance (attribute and raw payload), HTTP 401/403/404/429 error mapping, JQL validation success/failure
- `backend/tests/unit/onyx/connectors/jira_service_management/test_jsm_utils.py` — exhaustive coverage of the JSM field extraction helpers and comment handling

**Regression:** the full existing `backend/tests/unit/onyx/connectors/jira/` suite (34 tests) passes unchanged against the `JiraConnector` hook refactor.

**Static checks:** `ruff check`, `ruff format --check`, and `ty check` (CI-pinned version) pass on all new/modified backend files; the edited frontend files parse cleanly.

**Daily test:** `backend/tests/daily/connectors/jira_service_management/test_jsm_basic.py` follows the existing Jira daily test pattern and runs against a real JSM instance (e.g. `danswerai.atlassian.net`, project `ITSM`) using the existing `jira-user-email` / `jira-api-token` secrets; it asserts documents are branded as JSM, scoped to the configured project, carry a request type, and that slim docs match the browse URLs.

A short demo video of connector creation via the UI can be attached on request — happy to record one.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

/claim #2281

> **Disclosure:** This PR was authored by @Furox-Art (AI-assisted). Happy to adjust anything.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated Jira Service Management (JSM) connector that indexes all customer requests from a specified service desk project, resolving #2281.

**New Features**
- Subclasses `JiraConnector` to inherit checkpointed pagination, slim-doc retrieval, project hierarchy, and permission sync; documents are stamped with `DocumentSource.JIRA_SERVICE_MANAGEMENT`.
- Excludes JSM internal agent notes (`jsdPublic` false) by default; the `include_internal_comments` option indexes them tagged with an `[Internal Note]` prefix.
- Discovers JSM metadata (customer request type, organizations, SLA statuses) by stable display names instead of hard-coded custom field IDs, with structural fallback when discovery fails.
- Scopes custom JQL filters to the configured service desk project so a filter without its own project clause cannot widen indexing to other projects.
- `validate_connector_settings` requires a project key and verifies the project is a service desk project (`projectTypeKey == 'service_desk'`), mapping HTTP errors (401/403/404/429) to clear validation errors.
- Adds optional attachment indexing (off by default): attachments become separate documents linked to their ticket, with stable IDs and full/slim parity.
- Registers the new source in backend constants, the connector registry, Slack icons, and the frontend source map, connector config, and credential template.
- Adds unit and daily tests against a real JSM instance; the existing `JiraConnector` test suite passes unchanged.

<sup>Written for commit f14a5f5684521e9c7db6134fbc9d77418fee4dd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/14687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

